### PR TITLE
Feature/APP-2672 Force Products Currency to Euro

### DIFF
--- a/Sources/AppCoinsSDK/BuildConfiguration.swift
+++ b/Sources/AppCoinsSDK/BuildConfiguration.swift
@@ -12,9 +12,14 @@ import Adyen
 internal class BuildConfiguration {
     static internal let shared = BuildConfiguration()
     
-    // For now we only work on dev environment
-    static internal var environment: SDKEnvironment = .releaseSDKProd
+    static internal var isDev: Bool {
+        return Bundle.main.bundleIdentifier == "com.appcoins.trivialdrivesample.test"
+    }
     
+    static internal var environment: SDKEnvironment {
+        if BuildConfiguration.isDev { return .releaseSDKDev }
+        else { return .releaseSDKProd }
+    }
     
     static internal var packageName : String {
         return Bundle.main.bundleIdentifier ?? ""

--- a/Sources/AppCoinsSDK/Domain/Entities/AppcSDK.swift
+++ b/Sources/AppCoinsSDK/Domain/Entities/AppcSDK.swift
@@ -12,7 +12,9 @@ import MarketplaceKit
 public struct AppcSDK {
     
     static public func isAvailable() async -> Bool {
-        if #available(iOS 17.4, *) { 
+        if BuildConfiguration.isDev { return true } // Available for Dev
+        
+        if #available(iOS 17.4, *) {
             do {
                 let storefront = try await AppDistributor.current
                 switch storefront {

--- a/Sources/AppCoinsSDK/Domain/Repositories/Product/ProductRepository.swift
+++ b/Sources/AppCoinsSDK/Domain/Repositories/Product/ProductRepository.swift
@@ -12,8 +12,8 @@ internal class ProductRepository: ProductRepositoryProtocol {
     private let productService: AppCoinProductService = AppCoinProductServiceClient()
     private let billingService: AppCoinBillingService = AppCoinBillingClient()
 
-    internal func getProduct(domain: String, product: String, completion: @escaping (Result<Product, ProductServiceError>) -> Void) {
-        productService.getProductInformation(domain: domain, sku: product) {
+    internal func getProduct(domain: String, product: String, currency: Coin = .EUR, completion: @escaping (Result<Product, ProductServiceError>) -> Void) {
+        productService.getProductInformation(domain: domain, sku: product, currency: currency) {
             result in
             
             switch result {
@@ -29,8 +29,8 @@ internal class ProductRepository: ProductRepositoryProtocol {
         }
     }
     
-    internal func getAllProducts(domain: String, completion: @escaping (Result<[Product], ProductServiceError>) -> Void) {
-        productService.getProductInformation(domain: domain) {
+    internal func getAllProducts(domain: String, currency: Coin = .EUR, completion: @escaping (Result<[Product], ProductServiceError>) -> Void) {
+        productService.getProductInformation(domain: domain, currency: currency) {
             result in
             
             switch result {

--- a/Sources/AppCoinsSDK/Domain/Repositories/Product/ProductRepositoryProtocol.swift
+++ b/Sources/AppCoinsSDK/Domain/Repositories/Product/ProductRepositoryProtocol.swift
@@ -9,8 +9,8 @@ import Foundation
 
 internal protocol ProductRepositoryProtocol {
     
-    func getProduct(domain: String, product: String, completion: @escaping (Result<Product, ProductServiceError>) -> Void)
-    func getAllProducts(domain: String, completion: @escaping (Result<[Product], ProductServiceError>) -> Void)
+    func getProduct(domain: String, product: String, currency: Coin, completion: @escaping (Result<Product, ProductServiceError>) -> Void)
+    func getAllProducts(domain: String, currency: Coin, completion: @escaping (Result<[Product], ProductServiceError>) -> Void)
     func getProductAppcValue(product: Product, completion: @escaping (Result<String, BillingError>) -> Void)
     
 }

--- a/Sources/AppCoinsSDK/Domain/UseCases/ProductUseCases.swift
+++ b/Sources/AppCoinsSDK/Domain/UseCases/ProductUseCases.swift
@@ -17,12 +17,12 @@ internal class ProductUseCases {
         self.repository = repository
     }
     
-    internal func getProduct(domain: String, product: String, completion: @escaping (Result<Product, ProductServiceError>) -> Void) {
-        repository.getProduct(domain: domain, product: product) { result in completion(result) }
+    internal func getProduct(domain: String, product: String, currency: Coin = .EUR, completion: @escaping (Result<Product, ProductServiceError>) -> Void) {
+        repository.getProduct(domain: domain, product: product, currency: currency) { result in completion(result) }
     }
     
-    internal func getAllProducts(domain: String, completion: @escaping (Result<[Product], ProductServiceError>) -> Void) {
-        repository.getAllProducts(domain: domain) { result in completion(result) }
+    internal func getAllProducts(domain: String, currency: Coin = .EUR, completion: @escaping (Result<[Product], ProductServiceError>) -> Void) {
+        repository.getAllProducts(domain: domain, currency: currency) { result in completion(result) }
     }
     
     internal func getProductAppcValue(product: Product, completion: @escaping (Result<String, BillingError>) -> Void) {

--- a/Sources/AppCoinsSDK/Models/Services/Product/AppCoinProductService.swift
+++ b/Sources/AppCoinsSDK/Models/Services/Product/AppCoinProductService.swift
@@ -9,9 +9,9 @@ import Foundation
 
 internal protocol AppCoinProductService {
     
-    func getProductInformation(domain: String, result: @escaping (Result<GetProductInformationRaw, ProductServiceError>) -> Void)
+    func getProductInformation(domain: String, currency: Coin, result: @escaping (Result<GetProductInformationRaw, ProductServiceError>) -> Void)
     
-    func getProductInformation(domain: String, sku: String, result: @escaping (Result<GetProductInformationRaw, ProductServiceError>) -> Void)
+    func getProductInformation(domain: String, sku: String, currency: Coin, result: @escaping (Result<GetProductInformationRaw, ProductServiceError>) -> Void)
     
     func acknowledgePurchase(domain: String, uid: String, wa: Wallet, completion: @escaping (Result<Bool, TransactionError>) -> Void)
     

--- a/Sources/AppCoinsSDK/Models/Services/Product/AppCoinProductServiceClient.swift
+++ b/Sources/AppCoinsSDK/Models/Services/Product/AppCoinProductServiceClient.swift
@@ -15,8 +15,8 @@ internal class AppCoinProductServiceClient : AppCoinProductService {
         self.endpoint = endpoint
     }
     
-    internal func getProductInformation(domain: String, result: @escaping (Result<GetProductInformationRaw, ProductServiceError>) -> Void) {
-        if let url = URL(string: endpoint + "/applications/\(domain)/inapp/consumables") {
+    internal func getProductInformation(domain: String, currency: Coin = .EUR, result: @escaping (Result<GetProductInformationRaw, ProductServiceError>) -> Void) {
+        if let url = URL(string: endpoint + "/applications/\(domain)/inapp/consumables?currency=\(currency.rawValue)") {
             let task = URLSession.shared.dataTask(with: url) { data, response, error in
                 if let error = error {
                     if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
@@ -36,8 +36,8 @@ internal class AppCoinProductServiceClient : AppCoinProductService {
         }
     }
     
-    internal func getProductInformation(domain: String, sku: String, result: @escaping (Result<GetProductInformationRaw, ProductServiceError>) -> Void) {
-        if let url = URL(string: endpoint + "/applications/\(domain)/inapp/consumables/?skus=\(sku)") {
+    internal func getProductInformation(domain: String, sku: String, currency: Coin = .EUR, result: @escaping (Result<GetProductInformationRaw, ProductServiceError>) -> Void) {
+        if let url = URL(string: endpoint + "/applications/\(domain)/inapp/consumables/?skus=\(sku)&currency=\(currency.rawValue)") {
             let task = URLSession.shared.dataTask(with: url) { data, response, error in
                 if let error = error {
                     if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {


### PR DESCRIPTION
**What does this PR do?**

It forces the Product endpoints to return products with prices represented in Euro, considering this is the only currency currently supported.

It also adds configurations to facilitate development by making isAvailable always `true` when the bundle ID is Trivial Drive Dev's bundle ID.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] Sources/AppCoinsSDK/Models/Services/Product/AppCoinProductServiceClient.swift

**How should this be manually tested?**

It has already been tested in multiple locations.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2672](https://aptoide.atlassian.net/browse/APP-2672)

**Questions:**


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass
