### PR TITLE
Feature/APP-2716 Send GuestUID OEMID Transaction

### DIFF
--- a/Sources/AppCoinsSDK/BuildConfiguration.swift
+++ b/Sources/AppCoinsSDK/BuildConfiguration.swift
@@ -115,6 +115,8 @@ internal class BuildConfiguration {
         }
     }
     
+    static internal var aptoideOEMID = "a37f1d7a4599d0ba60f23f9ff7b9ce95"
+    
     static internal var userUID =  UIDevice.current.identifierForVendor!.uuidString
     
     static internal var integratedMethods: [Method] = [.appc, .paypalAdyen, .paypalDirect, .creditCard]

--- a/Sources/AppCoinsSDK/Domain/Entities/TransactionParameters.swift
+++ b/Sources/AppCoinsSDK/Domain/Entities/TransactionParameters.swift
@@ -17,10 +17,12 @@ internal struct TransactionParameters {
     internal let product: String
     internal let appcAmount: String
     internal var method: String?
+    internal let guestUID: String?
+    internal let oemID: String?
     internal let metadata: String?
     internal let reference: String?
 
-    init(value: String, currency: String, developerWa: String, userWa: String, domain: String, product: String, appcAmount: String, method: String? = nil, metadata: String?, reference: String?) {
+    init(value: String, currency: String, developerWa: String, userWa: String, domain: String, product: String, appcAmount: String, method: String? = nil, guestUID: String?, oemID: String?, metadata: String?, reference: String?) {
         self.value = value
         self.currency = currency
         self.developerWa = developerWa
@@ -29,6 +31,8 @@ internal struct TransactionParameters {
         self.product = product
         self.appcAmount = appcAmount
         self.method = method
+        self.guestUID = guestUID
+        self.oemID = oemID
         self.metadata = metadata
         self.reference = reference
     }

--- a/Sources/AppCoinsSDK/Domain/Repositories/MMP/MMPRepository.swift
+++ b/Sources/AppCoinsSDK/Domain/Repositories/MMP/MMPRepository.swift
@@ -32,7 +32,11 @@ internal class MMPRepository: MMPRepositoryProtocol {
     
     internal func getGuestUID() -> String? {
         if let guestUID = UserDefaults.standard.string(forKey: "attribution-guestuid") { return guestUID }
-        
         return nil
+    }
+    
+    internal func getOEMID() -> String? {
+        if let oemID = UserDefaults.standard.string(forKey: "attribution-oemid") { return oemID }
+        else { return BuildConfiguration.aptoideOEMID }
     }
 }

--- a/Sources/AppCoinsSDK/Domain/Repositories/MMP/MMPRepositoryProtocol.swift
+++ b/Sources/AppCoinsSDK/Domain/Repositories/MMP/MMPRepositoryProtocol.swift
@@ -10,4 +10,5 @@ import Foundation
 internal protocol MMPRepositoryProtocol {
     func getAttribution()
     func getGuestUID() -> String?
+    func getOEMID() -> String?
 }

--- a/Sources/AppCoinsSDK/Domain/UseCases/MMPUseCases.swift
+++ b/Sources/AppCoinsSDK/Domain/UseCases/MMPUseCases.swift
@@ -12,12 +12,14 @@ internal class MMPUseCases {
     internal static let shared: MMPUseCases = MMPUseCases()
     private let repository: MMPRepositoryProtocol
     
-    internal init(repository: MMPRepositoryProtocol = MMPRepository()) {
+    private init(repository: MMPRepositoryProtocol = MMPRepository()) {
         self.repository = repository
     }
     
     internal func getAttribution() { repository.getAttribution() }
     
     internal func getGuestUID() -> String? { return repository.getGuestUID() }
+    
+    internal func getOEMID() -> String? { return repository.getOEMID() }
     
 }

--- a/Sources/AppCoinsSDK/Models/Raws/CreateAPPCTransactionRaw.swift
+++ b/Sources/AppCoinsSDK/Models/Raws/CreateAPPCTransactionRaw.swift
@@ -17,6 +17,8 @@ internal struct CreateAPPCTransactionRaw: Codable {
     internal let type: String
     internal let developerWa: String
     internal let channel: String
+    internal let guestUID: String?
+    internal let oemID: String?
     internal let metadata: String?
     internal let reference: String?
     
@@ -29,6 +31,8 @@ internal struct CreateAPPCTransactionRaw: Codable {
         case type = "type"
         case developerWa = "wallets.developer"
         case channel = "channel"
+        case guestUID = "entity.guest_id"
+        case oemID = "entity.oemid"
         case metadata = "metadata"
         case reference = "reference"
     }
@@ -37,7 +41,7 @@ internal struct CreateAPPCTransactionRaw: Codable {
         // normalizes the price to adjust to different time zone price syntaxes
         let normalizedPrice = (parameters.appcAmount).replacingOccurrences(of: ",", with: ".")
         
-        return CreateAPPCTransactionRaw(origin: "BDS", domain: parameters.domain, price: normalizedPrice, priceCurrency: "APPC", product: parameters.product, type: "INAPP", developerWa: parameters.developerWa, channel: "IOS", metadata: parameters.metadata, reference: parameters.reference
+        return CreateAPPCTransactionRaw(origin: "BDS", domain: parameters.domain, price: normalizedPrice, priceCurrency: "APPC", product: parameters.product, type: "INAPP", developerWa: parameters.developerWa, channel: "IOS", guestUID: parameters.guestUID, oemID: parameters.oemID, metadata: parameters.metadata, reference: parameters.reference
         )
     }
     

--- a/Sources/AppCoinsSDK/Models/Raws/CreateAdyenTransactionRaw.swift
+++ b/Sources/AppCoinsSDK/Models/Raws/CreateAdyenTransactionRaw.swift
@@ -21,6 +21,8 @@ internal struct CreateAdyenTransactionRaw: Codable {
     internal let paymentChannel: String
     internal let paymentReturnUrl: String?
     internal let userWa: String
+    internal let guestUID: String?
+    internal let oemID: String?
     internal let metadata: String?
     internal let reference: String?
     
@@ -37,6 +39,8 @@ internal struct CreateAdyenTransactionRaw: Codable {
         case paymentChannel = "payment.channel"
         case paymentReturnUrl = "payment.return_url"
         case userWa = "wallets.user"
+        case guestUID = "entity.guest_id"
+        case oemID = "entity.oemid"
         case metadata = "metadata"
         case reference = "reference"
     }
@@ -50,7 +54,7 @@ internal struct CreateAdyenTransactionRaw: Codable {
             return .success(
                 CreateAdyenTransactionRaw(
                     origin: "BDS", domain: parameters.domain, price: normalizedPrice, priceCurrency: parameters.currency,
-                    product: parameters.product, type: "INAPP", method: method, developerWa: parameters.developerWa, channel: "IOS", paymentChannel: "IOS", paymentReturnUrl: "\(bundleID).iap://api.blockchainds.com/broker", userWa: parameters.userWa, metadata: parameters.metadata, reference: parameters.reference
+                    product: parameters.product, type: "INAPP", method: method, developerWa: parameters.developerWa, channel: "IOS", paymentChannel: "IOS", paymentReturnUrl: "\(bundleID).iap://api.blockchainds.com/broker", userWa: parameters.userWa, guestUID: parameters.guestUID, oemID: parameters.oemID, metadata: parameters.metadata, reference: parameters.reference
                 )
             )
         } else { return .failure(.failed()) }

--- a/Sources/AppCoinsSDK/Models/Raws/CreateBAPayPalTransactionRaw.swift
+++ b/Sources/AppCoinsSDK/Models/Raws/CreateBAPayPalTransactionRaw.swift
@@ -18,6 +18,8 @@ internal struct CreateBAPayPalTransactionRaw: Codable {
     internal let developerWa: String
     internal let userWa: String
     internal let channel: String
+    internal let guestUID: String?
+    internal let oemID: String?
     internal let metadata: String?
     internal let reference: String?
     
@@ -31,6 +33,8 @@ internal struct CreateBAPayPalTransactionRaw: Codable {
         case developerWa = "wallets.developer"
         case userWa = "wallets.user"
         case channel = "channel"
+        case guestUID = "entity.guest_id"
+        case oemID = "entity.oemid"
         case metadata = "metadata"
         case reference = "reference"
     }
@@ -40,7 +44,7 @@ internal struct CreateBAPayPalTransactionRaw: Codable {
         let normalizedPrice = parameters.value.replacingOccurrences(of: ",", with: ".")
         
         return CreateBAPayPalTransactionRaw(
-            origin: "BDS", domain: parameters.domain, price: normalizedPrice, priceCurrency: parameters.currency, product: parameters.product, type: "INAPP", developerWa: parameters.developerWa, userWa: parameters.userWa, channel: "IOS", metadata: parameters.metadata, reference: parameters.reference
+            origin: "BDS", domain: parameters.domain, price: normalizedPrice, priceCurrency: parameters.currency, product: parameters.product, type: "INAPP", developerWa: parameters.developerWa, userWa: parameters.userWa, channel: "IOS", guestUID: parameters.guestUID, oemID: parameters.oemID, metadata: parameters.metadata, reference: parameters.reference
         )
     }
     

--- a/Sources/AppCoinsSDK/UI/Purchase/ViewModels/TransactionViewModel.swift
+++ b/Sources/AppCoinsSDK/UI/Purchase/ViewModels/TransactionViewModel.swift
@@ -94,8 +94,11 @@ internal class TransactionViewModel : ObservableObject {
                                                 // 6. Build the Transaction UI
                                                 self.transaction = TransactionAlertUi(domain: domain, description: product.title, category: .IAP, sku: product.sku, moneyAmount: moneyAmount, moneyCurrency: product.priceCurrency, appcAmount: appcValue, bonusCurrency: transactionBonus.currency.symbol, bonusAmount: transactionBonus.value, walletBalance: "\(balanceCurrency)\(String(format: "%.2f", balanceValue))", paymentMethods: availablePaymentMethods)
                                                 
+                                                let guestUID = MMPUseCases.shared.getGuestUID()
+                                                let oemID = MMPUseCases.shared.getOEMID()
+                                                
                                                 // 7. Build the parameters to process the transaction
-                                                self.transactionParameters = TransactionParameters(value: String(moneyAmount), currency: Coin.EUR.rawValue, developerWa: developerWa, userWa: wallet.getWalletAddress(), domain: domain, product: product.sku, appcAmount: String(appcValue), metadata: self.metadata, reference: self.reference)
+                                                self.transactionParameters = TransactionParameters(value: String(moneyAmount), currency: Coin.EUR.rawValue, developerWa: developerWa, userWa: wallet.getWalletAddress(), domain: domain, product: product.sku, appcAmount: String(appcValue), guestUID: guestUID, oemID: oemID, metadata: self.metadata, reference: self.reference)
                                                 
                                                 // 8. Show payment method options
                                                 self.showPaymentMethodsOnBuild(balance: balance)


### PR DESCRIPTION
**What does this PR do?**

On endpoints: `/gateways/appcoins_credits/transactions`, `/gateways/adyen_v2/session` and `/gateways/paypal/transactions`, we send two new body parameters: `entity.oemid` and `entity.guest_id`, which are set to the values we have stored from the `/attribution` request.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] Sources/AppCoinsSDK/Domain/Entities/TransactionParameters.swift
- [ ] Sources/AppCoinsSDK/Models/Raws/CreateAPPCTransactionRaw.swift
- [ ] Sources/AppCoinsSDK/Models/Raws/CreateAdyenTransactionRaw.swift
- [ ] Sources/AppCoinsSDK/Models/Raws/CreateBAPayPalTransactionRaw.swift

**How should this be manually tested?**

You can print the body of the requests we are sending on these endpoints and check if fields `entity.oemid` and `entity.guest_id` are defined.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2716](https://aptoide.atlassian.net/browse/APP-2716)

**Questions:**




**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass
