### PR TITLE
Feature/app 2631 pay flow sdk integration

### DIFF
--- a/Sources/AppCoinsSDK/BuildConfiguration.swift
+++ b/Sources/AppCoinsSDK/BuildConfiguration.swift
@@ -134,7 +134,7 @@ internal class BuildConfiguration {
         return Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
     }
     
-    static internal var vercode = 9
+    static internal var vercode = 10
 }
 
 internal enum SDKEnvironment: String {

--- a/Sources/AppCoinsSDK/BuildConfiguration.swift
+++ b/Sources/AppCoinsSDK/BuildConfiguration.swift
@@ -115,11 +115,26 @@ internal class BuildConfiguration {
         }
     }
     
+    static internal var payFlowServiceBaseURL: String {
+        switch environment {
+        case .debugSDKDev, .releaseSDKDev:
+            return "https://payflowsdk.dev.aptoide.com"
+        case .debugSDKProd, .releaseSDKProd:
+            return "https://payflowsdk.aptoide.com"
+        }
+    }
+    
     static internal var aptoideOEMID = "a37f1d7a4599d0ba60f23f9ff7b9ce95"
     
     static internal var userUID =  UIDevice.current.identifierForVendor!.uuidString
     
     static internal var integratedMethods: [Method] = [.appc, .paypalAdyen, .paypalDirect, .creditCard]
+    
+    static internal var packageVersion : String {
+        return Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+    }
+    
+    static internal var vercode = 9
 }
 
 internal enum SDKEnvironment: String {

--- a/Sources/AppCoinsSDK/Domain/Entities/AppcSDKInternal.swift
+++ b/Sources/AppCoinsSDK/Domain/Entities/AppcSDKInternal.swift
@@ -10,7 +10,7 @@ import Foundation
 internal class AppcSDKInternal {
     
     static internal func initialize() {
-        MMPUseCases.shared.getAttribution { PayFlowUseCases.shared.setPayFlow() }
         AnalyticsUseCases.shared.initialize()
+        MMPUseCases.shared.getAttribution { PayFlowUseCases.shared.setPayFlow() }
     }
 }

--- a/Sources/AppCoinsSDK/Domain/Entities/AppcSDKInternal.swift
+++ b/Sources/AppCoinsSDK/Domain/Entities/AppcSDKInternal.swift
@@ -10,7 +10,7 @@ import Foundation
 internal class AppcSDKInternal {
     
     static internal func initialize() {
-        AnalyticsUseCases.shared.initialize()
         MMPUseCases.shared.getAttribution { PayFlowUseCases.shared.setPayFlow() }
+        AnalyticsUseCases.shared.initialize()
     }
 }

--- a/Sources/AppCoinsSDK/Domain/Entities/AppcSDKInternal.swift
+++ b/Sources/AppCoinsSDK/Domain/Entities/AppcSDKInternal.swift
@@ -10,7 +10,7 @@ import Foundation
 internal class AppcSDKInternal {
     
     static internal func initialize() {
-        MMPUseCases.shared.getAttribution()
+        MMPUseCases.shared.getAttribution { PayFlowUseCases.shared.setPayFlow() }
         AnalyticsUseCases.shared.initialize()
     }
 }

--- a/Sources/AppCoinsSDK/Domain/Entities/AppcSDKInternal.swift
+++ b/Sources/AppCoinsSDK/Domain/Entities/AppcSDKInternal.swift
@@ -10,7 +10,9 @@ import Foundation
 internal class AppcSDKInternal {
     
     static internal func initialize() {
-        MMPUseCases.shared.getAttribution { PayFlowUseCases.shared.setPayFlow() }
+        DispatchQueue.global(qos: .background).async {
+            MMPUseCases.shared.getAttribution { PayFlowUseCases.shared.setPayFlow() }
+        }
         AnalyticsUseCases.shared.initialize()
     }
 }

--- a/Sources/AppCoinsSDK/Domain/Entities/AppcSDKInternal.swift
+++ b/Sources/AppCoinsSDK/Domain/Entities/AppcSDKInternal.swift
@@ -10,9 +10,7 @@ import Foundation
 internal class AppcSDKInternal {
     
     static internal func initialize() {
-        DispatchQueue.global(qos: .background).async {
-            MMPUseCases.shared.getAttribution { PayFlowUseCases.shared.setPayFlow() }
-        }
+        MMPUseCases.shared.getAttribution { PayFlowUseCases.shared.setPayFlow() }
         AnalyticsUseCases.shared.initialize()
     }
 }

--- a/Sources/AppCoinsSDK/Domain/Entities/PayFlow/PayFlowError.swift
+++ b/Sources/AppCoinsSDK/Domain/Entities/PayFlow/PayFlowError.swift
@@ -1,0 +1,13 @@
+//
+//  File.swift
+//  
+//
+//  Created by Graciano Caldeira on 25/07/2024.
+//
+
+import Foundation
+
+internal enum PayFlowError: Error {
+    case failed
+    case noInternet
+}

--- a/Sources/AppCoinsSDK/Domain/Entities/PayFlow/PayFlowType.swift
+++ b/Sources/AppCoinsSDK/Domain/Entities/PayFlow/PayFlowType.swift
@@ -10,4 +10,26 @@ import Foundation
 internal enum PayFlowType: String {
     case standard
     case d2c
+    
+    init(raw: PayFlowDataRaw) {
+        if let paymentFlow = raw.paymentMethods.iosSDK?.paymentFlow {
+            switch paymentFlow {
+            case "D2C":
+                self = .d2c
+            default:
+                self = .standard
+            }
+        } else {
+            self = .standard
+        }
+    }
+    
+    var rawValue: String {
+        switch self {
+        case .standard:
+            return "standard"
+        case .d2c:
+            return "d2c"
+        }
+    }
 }

--- a/Sources/AppCoinsSDK/Domain/Entities/PayFlow/PayFlowType.swift
+++ b/Sources/AppCoinsSDK/Domain/Entities/PayFlow/PayFlowType.swift
@@ -1,0 +1,13 @@
+//
+//  PayFlowType.swift
+//
+//
+//  Created by Graciano Caldeira on 25/07/2024.
+//
+
+import Foundation
+
+internal enum PayFlowType: String {
+    case standard
+    case d2c
+}

--- a/Sources/AppCoinsSDK/Domain/Repositories/MMP/MMPRepository.swift
+++ b/Sources/AppCoinsSDK/Domain/Repositories/MMP/MMPRepository.swift
@@ -34,7 +34,7 @@ internal class MMPRepository: MMPRepositoryProtocol {
         return nil
     }
     
-    internal func getOEMID() -> String? {
+    internal func getOEMID() -> String {
         if let oemID = UserDefaults.standard.string(forKey: "attribution-oemid") { return oemID }
         else { return BuildConfiguration.aptoideOEMID }
     }

--- a/Sources/AppCoinsSDK/Domain/Repositories/MMP/MMPRepository.swift
+++ b/Sources/AppCoinsSDK/Domain/Repositories/MMP/MMPRepository.swift
@@ -26,7 +26,7 @@ internal class MMPRepository: MMPRepositoryProtocol {
                 }
                 completion()
             }
-        }
+        } else { completion() }
     }
     
     internal func getGuestUID() -> String? {

--- a/Sources/AppCoinsSDK/Domain/Repositories/MMP/MMPRepository.swift
+++ b/Sources/AppCoinsSDK/Domain/Repositories/MMP/MMPRepository.swift
@@ -11,8 +11,7 @@ internal class MMPRepository: MMPRepositoryProtocol {
     
     private let MMPService: MMPService = MMPClient()
     
-    internal func getAttribution() {
-        
+    internal func getAttribution(completion: @escaping () -> Void) {
         let oemID = UserDefaults.standard.string(forKey: "attribution-oemid")
         let guestUID = UserDefaults.standard.string(forKey: "attribution-guestuid")
         
@@ -22,8 +21,8 @@ internal class MMPRepository: MMPRepositoryProtocol {
                 switch result {
                 case .success(let attributionRaw):
                     UserDefaults.standard.set(String(attributionRaw.guestUID), forKey: "attribution-guestuid")
-                    
                     if let rawOemID = attributionRaw.oemID, rawOemID != "" { UserDefaults.standard.set(rawOemID, forKey: "attribution-oemid") }
+                    completion()
                 case .failure: break
                 }
             }

--- a/Sources/AppCoinsSDK/Domain/Repositories/MMP/MMPRepository.swift
+++ b/Sources/AppCoinsSDK/Domain/Repositories/MMP/MMPRepository.swift
@@ -24,9 +24,9 @@ internal class MMPRepository: MMPRepositoryProtocol {
                     if let rawOemID = attributionRaw.oemID, rawOemID != "" { UserDefaults.standard.set(rawOemID, forKey: "attribution-oemid") }
                 case .failure: break
                 }
+                completion()
             }
         }
-        completion()
     }
     
     internal func getGuestUID() -> String? {

--- a/Sources/AppCoinsSDK/Domain/Repositories/MMP/MMPRepository.swift
+++ b/Sources/AppCoinsSDK/Domain/Repositories/MMP/MMPRepository.swift
@@ -22,11 +22,11 @@ internal class MMPRepository: MMPRepositoryProtocol {
                 case .success(let attributionRaw):
                     UserDefaults.standard.set(String(attributionRaw.guestUID), forKey: "attribution-guestuid")
                     if let rawOemID = attributionRaw.oemID, rawOemID != "" { UserDefaults.standard.set(rawOemID, forKey: "attribution-oemid") }
-                    completion()
                 case .failure: break
                 }
             }
         }
+        completion()
     }
     
     internal func getGuestUID() -> String? {

--- a/Sources/AppCoinsSDK/Domain/Repositories/MMP/MMPRepositoryProtocol.swift
+++ b/Sources/AppCoinsSDK/Domain/Repositories/MMP/MMPRepositoryProtocol.swift
@@ -10,5 +10,5 @@ import Foundation
 internal protocol MMPRepositoryProtocol {
     func getAttribution(completion: @escaping () -> Void)
     func getGuestUID() -> String?
-    func getOEMID() -> String?
+    func getOEMID() -> String
 }

--- a/Sources/AppCoinsSDK/Domain/Repositories/MMP/MMPRepositoryProtocol.swift
+++ b/Sources/AppCoinsSDK/Domain/Repositories/MMP/MMPRepositoryProtocol.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 internal protocol MMPRepositoryProtocol {
-    func getAttribution()
+    func getAttribution(completion: @escaping () -> Void)
     func getGuestUID() -> String?
     func getOEMID() -> String?
 }

--- a/Sources/AppCoinsSDK/Domain/Repositories/PayFlow/PayFlowRepository.swift
+++ b/Sources/AppCoinsSDK/Domain/Repositories/PayFlow/PayFlowRepository.swift
@@ -10,14 +10,9 @@ import Foundation
 internal class PayFlowRepository: PayFlowRepositoryProtocol {
     
     private let PayFlowService: PayFlowService = PayFlowClient()
-    private let mmpRepository: MMPRepositoryProtocol
     
-    internal init(repository: MMPRepositoryProtocol = MMPRepository()) {
-        self.mmpRepository = repository
-    }
-    
-    internal func setPayFlow() {
-        self.PayFlowService.setPayFlow(package: BuildConfiguration.packageName, packageVercode: BuildConfiguration.packageVersion, sdkVercode: BuildConfiguration.vercode, locale: Locale.current.regionCode?.lowercased(), oemID: mmpRepository.getOEMID(), oemIDType: nil, country: nil, os: "ios") { result in
+    internal func setPayFlow(oemID: String) {
+        self.PayFlowService.setPayFlow(package: BuildConfiguration.packageName, packageVercode: BuildConfiguration.packageVersion, sdkVercode: BuildConfiguration.vercode, locale: Locale.current.regionCode?.lowercased(), oemID: oemID, oemIDType: nil, country: nil, os: "ios") { result in
             switch result {
             case .success(let payFlowDataRaw):
                 try? Utils.writeToPreferences(key: "pay-flow-type", value: payFlowDataRaw.paymentFlow.lowercased())

--- a/Sources/AppCoinsSDK/Domain/Repositories/PayFlow/PayFlowRepository.swift
+++ b/Sources/AppCoinsSDK/Domain/Repositories/PayFlow/PayFlowRepository.swift
@@ -15,7 +15,8 @@ internal class PayFlowRepository: PayFlowRepositoryProtocol {
         self.PayFlowService.setPayFlow(package: BuildConfiguration.packageName, packageVercode: BuildConfiguration.packageVersion, sdkVercode: BuildConfiguration.vercode, locale: Locale.current.regionCode?.lowercased(), oemID: oemID, oemIDType: nil, country: nil, os: "ios") { result in
             switch result {
             case .success(let payFlowDataRaw):
-                try? Utils.writeToPreferences(key: "pay-flow-type", value: payFlowDataRaw.paymentFlow.lowercased())
+                let payFlowType = PayFlowType(raw: payFlowDataRaw)
+                try? Utils.writeToPreferences(key: "pay-flow-type", value: payFlowType.rawValue)
             case .failure:
                 break
             }
@@ -23,7 +24,6 @@ internal class PayFlowRepository: PayFlowRepositoryProtocol {
     }
     
     func getPayFlow() -> PayFlowType {
-        
         if Utils.readFromPreferences(key: "pay-flow-type") == PayFlowType.d2c.rawValue {
             return .d2c
         } else { return .standard }

--- a/Sources/AppCoinsSDK/Domain/Repositories/PayFlow/PayFlowRepository.swift
+++ b/Sources/AppCoinsSDK/Domain/Repositories/PayFlow/PayFlowRepository.swift
@@ -20,7 +20,7 @@ internal class PayFlowRepository: PayFlowRepositoryProtocol {
         self.PayFlowService.setPayFlow(package: BuildConfiguration.packageName, packageVercode: BuildConfiguration.packageVersion, sdkVercode: BuildConfiguration.vercode, locale: Locale.current.regionCode?.lowercased(), oemID: mmpRepository.getOEMID(), oemIDType: nil, country: nil, os: "ios") { result in
             switch result {
             case .success(let payFlowDataRaw):
-                try? Utils.writeToPreferences(key: "pay-flow-method", value: payFlowDataRaw.paymentFlow)
+                try? Utils.writeToPreferences(key: "pay-flow-type", value: payFlowDataRaw.paymentFlow)
             case .failure:
                 break
             }
@@ -29,7 +29,7 @@ internal class PayFlowRepository: PayFlowRepositoryProtocol {
     
     func getPayFlow() -> PayFlowType {
         
-        if Utils.readFromPreferences(key: "pay-flow-method") == PayFlowType.d2c.rawValue {
+        if Utils.readFromPreferences(key: "pay-flow-type") == PayFlowType.d2c.rawValue {
             return .d2c
         } else { return .standard }
     }

--- a/Sources/AppCoinsSDK/Domain/Repositories/PayFlow/PayFlowRepository.swift
+++ b/Sources/AppCoinsSDK/Domain/Repositories/PayFlow/PayFlowRepository.swift
@@ -20,7 +20,7 @@ internal class PayFlowRepository: PayFlowRepositoryProtocol {
         self.PayFlowService.setPayFlow(package: BuildConfiguration.packageName, packageVercode: BuildConfiguration.packageVersion, sdkVercode: BuildConfiguration.vercode, locale: Locale.current.regionCode?.lowercased(), oemID: mmpRepository.getOEMID(), oemIDType: nil, country: nil, os: "ios") { result in
             switch result {
             case .success(let payFlowDataRaw):
-                try? Utils.writeToPreferences(key: "pay-flow-type", value: payFlowDataRaw.paymentFlow)
+                try? Utils.writeToPreferences(key: "pay-flow-type", value: payFlowDataRaw.paymentFlow.lowercased())
             case .failure:
                 break
             }

--- a/Sources/AppCoinsSDK/Domain/Repositories/PayFlow/PayFlowRepository.swift
+++ b/Sources/AppCoinsSDK/Domain/Repositories/PayFlow/PayFlowRepository.swift
@@ -17,7 +17,7 @@ internal class PayFlowRepository: PayFlowRepositoryProtocol {
     }
     
     internal func setPayFlow() {
-        self.PayFlowService.setPayFlow(package: BuildConfiguration.packageName, packageVercode: BuildConfiguration.packageVersion, sdkVercode: BuildConfiguration.vercode, locale: nil, oemID: mmpRepository.getOEMID(), oemIDType: nil, country: nil, os: "ios") { result in
+        self.PayFlowService.setPayFlow(package: BuildConfiguration.packageName, packageVercode: BuildConfiguration.packageVersion, sdkVercode: BuildConfiguration.vercode, locale: Locale.current.regionCode?.lowercased(), oemID: mmpRepository.getOEMID(), oemIDType: nil, country: nil, os: "ios") { result in
             switch result {
             case .success(let payFlowDataRaw):
                 try? Utils.writeToPreferences(key: "pay-flow-method", value: payFlowDataRaw.paymentFlow)

--- a/Sources/AppCoinsSDK/Domain/Repositories/PayFlow/PayFlowRepository.swift
+++ b/Sources/AppCoinsSDK/Domain/Repositories/PayFlow/PayFlowRepository.swift
@@ -1,10 +1,34 @@
 //
-//  File.swift
-//  
+//  PayFlowRepository.swift
+//
 //
 //  Created by Graciano Caldeira on 25/07/2024.
 //
 
 import Foundation
 
-internal class PayFlowRepository: payflow
+internal class PayFlowRepository: PayFlowRepositoryProtocol {
+    
+    private let PayFlowService: PayFlowService = PayFlowClient()
+    
+    internal func setPayFlow() {
+        
+        let oemID = UserDefaults.standard.string(forKey: "attribution-oemid")
+        
+        self.PayFlowService.setPayFlow(package: BuildConfiguration.packageName, packageVercode: BuildConfiguration.packageVersion, sdkVercode: BuildConfiguration.vercode, locale: nil, oemID: oemID, oemIDType: nil, country: nil, os: "ios") { result in
+            switch result {
+            case .success(let payFlowDataRaw):
+                try? Utils.writeToPreferences(key: "pay-flow-method", value: payFlowDataRaw.paymentFlow)
+            case .failure:
+                break
+            }
+        }
+    }
+    
+    func getPayFlow() -> PayFlowType {
+        
+        if Utils.readFromPreferences(key: "pay-flow-method") == PayFlowType.d2c.rawValue {
+            return .d2c
+        } else { return .standard }
+    }
+}

--- a/Sources/AppCoinsSDK/Domain/Repositories/PayFlow/PayFlowRepository.swift
+++ b/Sources/AppCoinsSDK/Domain/Repositories/PayFlow/PayFlowRepository.swift
@@ -1,0 +1,10 @@
+//
+//  File.swift
+//  
+//
+//  Created by Graciano Caldeira on 25/07/2024.
+//
+
+import Foundation
+
+internal class PayFlowRepository: payflow

--- a/Sources/AppCoinsSDK/Domain/Repositories/PayFlow/PayFlowRepository.swift
+++ b/Sources/AppCoinsSDK/Domain/Repositories/PayFlow/PayFlowRepository.swift
@@ -10,12 +10,14 @@ import Foundation
 internal class PayFlowRepository: PayFlowRepositoryProtocol {
     
     private let PayFlowService: PayFlowService = PayFlowClient()
+    private let mmpRepository: MMPRepositoryProtocol
+    
+    internal init(repository: MMPRepositoryProtocol = MMPRepository()) {
+        self.mmpRepository = repository
+    }
     
     internal func setPayFlow() {
-        
-        let oemID = UserDefaults.standard.string(forKey: "attribution-oemid")
-        
-        self.PayFlowService.setPayFlow(package: BuildConfiguration.packageName, packageVercode: BuildConfiguration.packageVersion, sdkVercode: BuildConfiguration.vercode, locale: nil, oemID: oemID, oemIDType: nil, country: nil, os: "ios") { result in
+        self.PayFlowService.setPayFlow(package: BuildConfiguration.packageName, packageVercode: BuildConfiguration.packageVersion, sdkVercode: BuildConfiguration.vercode, locale: nil, oemID: mmpRepository.getOEMID(), oemIDType: nil, country: nil, os: "ios") { result in
             switch result {
             case .success(let payFlowDataRaw):
                 try? Utils.writeToPreferences(key: "pay-flow-method", value: payFlowDataRaw.paymentFlow)

--- a/Sources/AppCoinsSDK/Domain/Repositories/PayFlow/PayFlowRepositoryProtocol.swift
+++ b/Sources/AppCoinsSDK/Domain/Repositories/PayFlow/PayFlowRepositoryProtocol.swift
@@ -8,5 +8,6 @@
 import Foundation
 
 internal protocol PayFlowRepositoryProtocol {
-    
+    func setPayFlow()
+    func getPayFlow() -> PayFlowType
 }

--- a/Sources/AppCoinsSDK/Domain/Repositories/PayFlow/PayFlowRepositoryProtocol.swift
+++ b/Sources/AppCoinsSDK/Domain/Repositories/PayFlow/PayFlowRepositoryProtocol.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 internal protocol PayFlowRepositoryProtocol {
-    func setPayFlow()
+    func setPayFlow(oemID: String)
     func getPayFlow() -> PayFlowType
 }

--- a/Sources/AppCoinsSDK/Domain/Repositories/PayFlow/PayFlowRepositoryProtocol.swift
+++ b/Sources/AppCoinsSDK/Domain/Repositories/PayFlow/PayFlowRepositoryProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  File.swift
+//  
+//
+//  Created by Graciano Caldeira on 25/07/2024.
+//
+
+import Foundation
+
+internal protocol PayFlowRepositoryProtocol {
+    
+}

--- a/Sources/AppCoinsSDK/Domain/UseCases/MMPUseCases.swift
+++ b/Sources/AppCoinsSDK/Domain/UseCases/MMPUseCases.swift
@@ -16,7 +16,7 @@ internal class MMPUseCases {
         self.repository = repository
     }
     
-    internal func getAttribution() { repository.getAttribution() }
+    internal func getAttribution(completion: @escaping () -> Void) { repository.getAttribution { completion() } }
     
     internal func getGuestUID() -> String? { return repository.getGuestUID() }
     

--- a/Sources/AppCoinsSDK/Domain/UseCases/MMPUseCases.swift
+++ b/Sources/AppCoinsSDK/Domain/UseCases/MMPUseCases.swift
@@ -20,6 +20,6 @@ internal class MMPUseCases {
     
     internal func getGuestUID() -> String? { return repository.getGuestUID() }
     
-    internal func getOEMID() -> String? { return repository.getOEMID() }
+    internal func getOEMID() -> String { return repository.getOEMID() }
     
 }

--- a/Sources/AppCoinsSDK/Domain/UseCases/PayFlowUseCases.swift
+++ b/Sources/AppCoinsSDK/Domain/UseCases/PayFlowUseCases.swift
@@ -1,0 +1,22 @@
+//
+//  PayFlowUseCases.swift
+//
+//
+//  Created by Graciano Caldeira on 25/07/2024.
+//
+
+import Foundation
+
+internal class PayFlowUseCases {
+    
+    internal static let shared: PayFlowUseCases = PayFlowUseCases()
+    private let repository: PayFlowRepositoryProtocol
+    
+    private init(repository: PayFlowRepositoryProtocol = PayFlowRepository()) {
+        self.repository = repository
+    }
+    
+    internal func setPayFlow() { repository.setPayFlow() }
+    
+    internal func getPayFlow() -> PayFlowType { return repository.getPayFlow() }
+}

--- a/Sources/AppCoinsSDK/Domain/UseCases/PayFlowUseCases.swift
+++ b/Sources/AppCoinsSDK/Domain/UseCases/PayFlowUseCases.swift
@@ -11,12 +11,14 @@ internal class PayFlowUseCases {
     
     internal static let shared: PayFlowUseCases = PayFlowUseCases()
     private let repository: PayFlowRepositoryProtocol
+    private let mmpRepository: MMPRepositoryProtocol
     
-    private init(repository: PayFlowRepositoryProtocol = PayFlowRepository()) {
+    private init(repository: PayFlowRepositoryProtocol = PayFlowRepository(), mmpRepository: MMPRepositoryProtocol = MMPRepository()) {
         self.repository = repository
+        self.mmpRepository = mmpRepository
     }
     
-    internal func setPayFlow() { repository.setPayFlow() }
+    internal func setPayFlow() { repository.setPayFlow(oemID: mmpRepository.getOEMID()) }
     
     internal func getPayFlow() -> PayFlowType { return repository.getPayFlow() }
 }

--- a/Sources/AppCoinsSDK/Models/Raws/PayFlowDataRaw.swift
+++ b/Sources/AppCoinsSDK/Models/Raws/PayFlowDataRaw.swift
@@ -1,0 +1,39 @@
+//
+//  File.swift
+//  
+//
+//  Created by Graciano Caldeira on 26/07/2024.
+//
+
+import Foundation
+
+internal struct PayFlowDataRaw: Codable {
+    
+//    let paymentMethods: PaymentMethods
+//    
+//    enum CodingKeys: String, CodingKey {
+//        case paymentMethods = "payment_methods"
+//    }
+//}
+//
+//internal struct PaymentMethods: Codable {
+//    
+//    let iosSDK: IOSSdkData
+//    
+//    enum CodingKeys: String, CodingKey {
+//        case iosSDK = "ios_sdk"
+//    }
+//}
+//
+//internal struct IOSSdkData: Codable {
+    
+    let paymentFlow: String
+    let version: String
+    let priority: Int
+    
+    enum CodingKeys: String, CodingKey {
+        case paymentFlow = "payment_flow"
+        case version = "version"
+        case priority = "priority"
+    }
+}

--- a/Sources/AppCoinsSDK/Models/Raws/PayFlowDataRaw.swift
+++ b/Sources/AppCoinsSDK/Models/Raws/PayFlowDataRaw.swift
@@ -9,9 +9,27 @@ import Foundation
 
 internal struct PayFlowDataRaw: Codable {
     
+    let paymentMethods: PaymentMethodsPayFlowRaw
+    
+    enum CodingKeys: String, CodingKey {
+        case paymentMethods = "payment_methods"
+    }
+}
+
+internal struct PaymentMethodsPayFlowRaw: Codable {
+    
+    let iosSDK: iOSSDKPaymentMethodPayFlowRaw?
+    
+    enum CodingKeys: String, CodingKey {
+        case iosSDK = "ios_sdk"
+    }
+}
+
+internal struct iOSSDKPaymentMethodPayFlowRaw: Codable {
+    
     let paymentFlow: String
-    let version: String
-    let priority: Int
+    let version: String?
+    let priority: Int?
     
     enum CodingKeys: String, CodingKey {
         case paymentFlow = "payment_flow"

--- a/Sources/AppCoinsSDK/Models/Raws/PayFlowDataRaw.swift
+++ b/Sources/AppCoinsSDK/Models/Raws/PayFlowDataRaw.swift
@@ -9,24 +9,6 @@ import Foundation
 
 internal struct PayFlowDataRaw: Codable {
     
-//    let paymentMethods: PaymentMethods
-//    
-//    enum CodingKeys: String, CodingKey {
-//        case paymentMethods = "payment_methods"
-//    }
-//}
-//
-//internal struct PaymentMethods: Codable {
-//    
-//    let iosSDK: IOSSdkData
-//    
-//    enum CodingKeys: String, CodingKey {
-//        case iosSDK = "ios_sdk"
-//    }
-//}
-//
-//internal struct IOSSdkData: Codable {
-    
     let paymentFlow: String
     let version: String
     let priority: Int

--- a/Sources/AppCoinsSDK/Models/Services/PayFlow/PayFlowClient.swift
+++ b/Sources/AppCoinsSDK/Models/Services/PayFlow/PayFlowClient.swift
@@ -1,0 +1,63 @@
+//
+//  PayFlowClient.swift
+//  
+//
+//  Created by Graciano Caldeira on 25/07/2024.
+//
+
+import Foundation
+
+internal class PayFlowClient: PayFlowService {
+    
+    private let endpoint: String
+    
+    init(endpoint: String = BuildConfiguration.payFlowServiceBaseURL) {
+        self.endpoint = endpoint
+    }
+    
+    internal func setPayFlow(package: String, packageVercode: String, sdkVercode: Int, locale: String?, oemID: String?, oemIDType: String?, country: String?, os: String, result: @escaping (Result<PayFlowDataRaw, PayFlowError>) -> Void) {
+        if let requestUrl = URL(string: "\(endpoint)/api/v2/payment_flow") {
+            
+            var queryItems = [
+                URLQueryItem(name: "package", value: package),
+                URLQueryItem(name: "package_vercode", value: packageVercode),
+                URLQueryItem(name: "sdk_vercode", value: String(sdkVercode)),
+                URLQueryItem(name: "locale", value: locale),
+                URLQueryItem(name: "oemid", value: oemID),
+                URLQueryItem(name: "oemid_type", value: oemIDType),
+                URLQueryItem(name: "country", value: country),
+                URLQueryItem(name: "os", value: os)
+            ]
+            
+            queryItems = queryItems.filter { $0.value != nil }
+            var components = URLComponents(url: requestUrl, resolvingAgainstBaseURL: false)
+            components?.queryItems = queryItems
+            
+            guard let url = components?.url else { fatalError() }
+            
+            var request = URLRequest(url: url)
+            
+            request.httpMethod = "GET"
+            request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.timeoutInterval = 10
+            
+            let task = URLSession.shared.dataTask(with: request) { data, response, error in
+                
+                if let error = error {
+                    if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
+                        result(.failure(.noInternet))
+                    } else {
+                        result(.failure(.failed))
+                    }
+                } else {
+                    if let data = data, let findResult = try? JSONDecoder().decode(PayFlowDataRaw.self, from: data) {
+                        result(.success(findResult))
+                    }  else {
+                        result(.failure(.failed))
+                    }
+                }
+            }
+            task.resume()
+        }
+    }
+}

--- a/Sources/AppCoinsSDK/Models/Services/PayFlow/PayFlowClient.swift
+++ b/Sources/AppCoinsSDK/Models/Services/PayFlow/PayFlowClient.swift
@@ -33,7 +33,10 @@ internal class PayFlowClient: PayFlowService {
             var components = URLComponents(url: requestUrl, resolvingAgainstBaseURL: false)
             components?.queryItems = queryItems
             
-            guard let url = components?.url else { fatalError() }
+            guard let url = components?.url else {
+                result(.failure(.failed))
+                return
+            }
             
             var request = URLRequest(url: url)
             

--- a/Sources/AppCoinsSDK/Models/Services/PayFlow/PayFlowClient.swift
+++ b/Sources/AppCoinsSDK/Models/Services/PayFlow/PayFlowClient.swift
@@ -55,7 +55,7 @@ internal class PayFlowClient: PayFlowService {
                 } else {
                     if let data = data, let findResult = try? JSONDecoder().decode(PayFlowDataRaw.self, from: data) {
                         result(.success(findResult))
-                    }  else {
+                    } else {
                         result(.failure(.failed))
                     }
                 }

--- a/Sources/AppCoinsSDK/Models/Services/PayFlow/PayFlowService.swift
+++ b/Sources/AppCoinsSDK/Models/Services/PayFlow/PayFlowService.swift
@@ -1,0 +1,12 @@
+//
+//  PayFlowService.swift
+//  
+//
+//  Created by Graciano Caldeira on 25/07/2024.
+//
+
+import Foundation
+
+internal protocol PayFlowService {
+    func setPayFlow(package: String, packageVercode: String, sdkVercode: Int, locale: String?, oemID: String?, oemIDType: String?, country: String?, os: String, result: @escaping (Result<PayFlowDataRaw, PayFlowError>) -> Void)
+}


### PR DESCRIPTION
**What does this PR do?**

   This PR adds a call to AppTech PayFlowSDK endpoint which will return a payment method regarding this call's parameters

This PR adds a call to AppTech's PayFlowSDK endpoint, which will return a payment method based on the call's parameters

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AppcSDKInternal.swift
- [ ] PayFlowUseCases.swift
- [ ] PayFlowRepository.swift
- [ ] PayFlowClient.swift

**How should this be manually tested?**

  To test it, we can print the findResult in the setPayFlow method on the PayFlowClient.swift and verify if the value is stored by using the getPayFlow method on the AppcSDKInternal.swift

**What are the relevant tickets?**

  Tickets related to this pull-request: APP-2631

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass
