### PR TITLE
Feature/APP-2804 Set User Agent for SDK Service Requests

### DIFF
--- a/Sources/AppCoinsSDK/BuildConfiguration.swift
+++ b/Sources/AppCoinsSDK/BuildConfiguration.swift
@@ -120,6 +120,8 @@ internal class BuildConfiguration {
     static internal var userUID =  UIDevice.current.identifierForVendor!.uuidString
     
     static internal var integratedMethods: [Method] = [.appc, .paypalAdyen, .paypalDirect, .creditCard]
+    
+    static internal var sdkShortVersion: String = "1.2.0"
 }
 
 internal enum SDKEnvironment: String {

--- a/Sources/AppCoinsSDK/Models/Services/APPC/APPCServiceClient.swift
+++ b/Sources/AppCoinsSDK/Models/Services/APPC/APPCServiceClient.swift
@@ -18,7 +18,13 @@ internal class APPCServiceClient : APPCService {
     internal func getGuestWallet(guestUID: String, result: @escaping (Result<GuestWalletRaw, APPCServiceError>) -> Void) {
         let route = "/guest_wallet"
         if let url = URL(string: endpoint + route + "?id=\(guestUID)") {
-            let task = URLSession.shared.dataTask(with: url) { data, response, error in
+            
+            var request = URLRequest(url: url)
+            
+            let userAgent = "AppCoinsWalletIOS/.."
+            request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+            
+            let task = URLSession.shared.dataTask(with: request) { data, response, error in
                 if let error = error {
                     if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
                         result(.failure(.noInternet))

--- a/Sources/AppCoinsSDK/Models/Services/Aptoide/AptoideServiceClient.swift
+++ b/Sources/AppCoinsSDK/Models/Services/Aptoide/AptoideServiceClient.swift
@@ -18,7 +18,13 @@ internal class AptoideServiceClient : AptoideService {
     internal func getDeveloperWalletAddressByPackageName(package: String, result: @escaping (Result<FindDeveloperWalletAddressRaw, AptoideServiceError>) -> Void) {
         let route = "/bds/apks/package/getOwnerWallet"
         if let url = URL(string: endpoint + route + "/package_name=\(package)") {
-            let task = URLSession.shared.dataTask(with: url) { data, response, error in
+            
+            var request = URLRequest(url: url)
+            
+            let userAgent = "AppCoinsWalletIOS/.."
+            request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+            
+            let task = URLSession.shared.dataTask(with: request) { data, response, error in
                 if let error = error {
                     if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
                         result(.failure(.noInternet))

--- a/Sources/AppCoinsSDK/Models/Services/AptoideIOS/AptoideIOSServiceClient.swift
+++ b/Sources/AppCoinsSDK/Models/Services/AptoideIOS/AptoideIOSServiceClient.swift
@@ -19,7 +19,13 @@ internal class AptoideIOSServiceClient : AptoideIOSService {
         let route = "/applications"
         let package = "com.aptoide.appcoins-wallet"
         if let url = URL(string: endpoint + route + "/\(package)") {
-            let task = URLSession.shared.dataTask(with: url) { data, response, error in
+            
+            var request = URLRequest(url: url)
+            
+            let userAgent = "AppCoinsWalletIOS/.."
+            request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+            
+            let task = URLSession.shared.dataTask(with: request) { data, response, error in
                 if let error = error {
                     if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
                         result(.failure(.noInternet))

--- a/Sources/AppCoinsSDK/Models/Services/Gamification/AppCoinGamificationServiceClient.swift
+++ b/Sources/AppCoinsSDK/Models/Services/Gamification/AppCoinGamificationServiceClient.swift
@@ -18,7 +18,13 @@ internal class AppCoinGamificationServiceClient : AppCoinGamificationService {
     internal func getTransactionBonus(address: String, package_name: String, amount: String, currency: Coin, result: @escaping (Result<TransactionBonusRaw, TransactionError>) -> Void) {
         let route = "/bonus_forecast"
         if let url = URL(string: endpoint + route + "?address=\(address)&package_name=\(package_name)&amount=\(amount)&currency=\(currency.rawValue)") {
-            let task = URLSession.shared.dataTask(with: url) { data, response, error in
+            
+            var request = URLRequest(url: url)
+            
+            let userAgent = "AppCoinsWalletIOS/.."
+            request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+            
+            let task = URLSession.shared.dataTask(with: request) { data, response, error in
                 if let error = error {
                     if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
                         result(.failure(.noInternet))

--- a/Sources/AppCoinsSDK/Models/Services/MMP/MMPClient.swift
+++ b/Sources/AppCoinsSDK/Models/Services/MMP/MMPClient.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+import DeviceKit
+import UIKit
 
 internal class MMPClient: MMPService {
     
@@ -23,6 +25,9 @@ internal class MMPClient: MMPService {
             request.httpMethod = "GET"
             request.addValue("application/json", forHTTPHeaderField: "Content-Type")
             request.timeoutInterval = 10
+            
+            let userAgent = self.getMMPUserAgent()
+            request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
             
             let task = URLSession.shared.dataTask(with: request) { data, response, error in
                 
@@ -42,5 +47,25 @@ internal class MMPClient: MMPService {
             }
             task.resume()
         }
+    }
+    
+    internal func getMMPUserAgent() -> String {
+        let appName = "iOSAppCoinsSDK"
+        let appVersion = BuildConfiguration.sdkShortVersion
+        let deviceName = Device.current.description
+        let systemVersion = Device.current.systemVersion?.description ?? "Unknown iOS version"
+        let bundleIdentifier = Bundle.main.bundleIdentifier ?? "Unknown Bundle ID"
+        
+        // Device ID
+        let UID = UIDevice.current.identifierForVendor!.uuidString
+        
+        // missing
+        let apiLevel = ProcessInfo().operatingSystemVersion.majorVersion
+        let cpu = "arm64" // standard value for most recent devices, no apple framework to retrieve this information
+        let vercode = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "Unknown"
+        let md5 = Utils.md5("iOSAppCoinsSDK")
+        let resolution = "0x0"
+        
+        return "\(appName)/\(appVersion) (iPhone; iOS \(systemVersion); \(apiLevel); \(deviceName); \(cpu); \(bundleIdentifier); \(vercode); \(md5); \(resolution); \(UID))"
     }
 }

--- a/Sources/AppCoinsSDK/Models/Services/Product/AppCoinProductServiceClient.swift
+++ b/Sources/AppCoinsSDK/Models/Services/Product/AppCoinProductServiceClient.swift
@@ -17,7 +17,13 @@ internal class AppCoinProductServiceClient : AppCoinProductService {
     
     internal func getProductInformation(domain: String, currency: Coin = .EUR, result: @escaping (Result<GetProductInformationRaw, ProductServiceError>) -> Void) {
         if let url = URL(string: endpoint + "/applications/\(domain)/inapp/consumables?currency=\(currency.rawValue)") {
-            let task = URLSession.shared.dataTask(with: url) { data, response, error in
+            
+            var request = URLRequest(url: url)
+            
+            let userAgent = "AppCoinsWalletIOS/.."
+            request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+            
+            let task = URLSession.shared.dataTask(with: request) { data, response, error in
                 if let error = error {
                     if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
                         result(.failure(.noInternet))
@@ -38,7 +44,13 @@ internal class AppCoinProductServiceClient : AppCoinProductService {
     
     internal func getProductInformation(domain: String, sku: String, currency: Coin = .EUR, result: @escaping (Result<GetProductInformationRaw, ProductServiceError>) -> Void) {
         if let url = URL(string: endpoint + "/applications/\(domain)/inapp/consumables/?skus=\(sku)&currency=\(currency.rawValue)") {
-            let task = URLSession.shared.dataTask(with: url) { data, response, error in
+            
+            var request = URLRequest(url: url)
+            
+            let userAgent = "AppCoinsWalletIOS/.."
+            request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+            
+            let task = URLSession.shared.dataTask(with: request) { data, response, error in
                 if let error = error {
                     if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
                         result(.failure(.noInternet))
@@ -67,6 +79,9 @@ internal class AppCoinProductServiceClient : AppCoinProductService {
             if let ewt = wa.getEWT() {
                 request.setValue(ewt, forHTTPHeaderField: "Authorization")
             }
+            
+            let userAgent = "AppCoinsWalletIOS/.."
+            request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
             
             let task = URLSession.shared.dataTask(with: request) { data, response, error in
                 if let error = error {
@@ -101,6 +116,9 @@ internal class AppCoinProductServiceClient : AppCoinProductService {
                 request.setValue(ewt, forHTTPHeaderField: "Authorization")
             }
             
+            let userAgent = "AppCoinsWalletIOS/.."
+            request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+            
             let task = URLSession.shared.dataTask(with: request) { data, response, error in
                 if let error = error {
                     if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
@@ -133,6 +151,9 @@ internal class AppCoinProductServiceClient : AppCoinProductService {
                 request.setValue(ewt, forHTTPHeaderField: "Authorization")
             }
             
+            let userAgent = "AppCoinsWalletIOS/.."
+            request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+            
             let task = URLSession.shared.dataTask(with: request) { data, response, error in
                 if let error = error {
                     if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
@@ -161,6 +182,9 @@ internal class AppCoinProductServiceClient : AppCoinProductService {
             if let ewt = wa.getEWT() {
                 request.setValue(ewt, forHTTPHeaderField: "Authorization")
             }
+            
+            let userAgent = "AppCoinsWalletIOS/.."
+            request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
             
             let task = URLSession.shared.dataTask(with: request) { data, response, error in
                 if let error = error {
@@ -191,6 +215,9 @@ internal class AppCoinProductServiceClient : AppCoinProductService {
                 request.setValue(ewt, forHTTPHeaderField: "Authorization")
             }
             
+            let userAgent = "AppCoinsWalletIOS/.."
+            request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+            
             let task = URLSession.shared.dataTask(with: request) { data, response, error in
                 if let error = error {
                     if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
@@ -220,6 +247,9 @@ internal class AppCoinProductServiceClient : AppCoinProductService {
                 request.setValue(ewt, forHTTPHeaderField: "Authorization")
             }
             
+            let userAgent = "AppCoinsWalletIOS/.."
+            request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+            
             let task = URLSession.shared.dataTask(with: request) { data, response, error in
                 if let error = error {
                     if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
@@ -241,7 +271,13 @@ internal class AppCoinProductServiceClient : AppCoinProductService {
     
     internal func getDeveloperPublicKey(domain: String, completion: @escaping (Result<String, ProductServiceError>) -> Void) {
         if let url = URL(string: endpoint + "/applications/\(domain)/public-key") {
-            let task = URLSession.shared.dataTask(with: url) { data, response, error in
+            
+            var request = URLRequest(url: url)
+            
+            let userAgent = "AppCoinsWalletIOS/.."
+            request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+            
+            let task = URLSession.shared.dataTask(with: request) { data, response, error in
                 if let error = error {
                     if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
                         completion(.failure(.noInternet))

--- a/Sources/AppCoinsSDK/Models/Services/Transaction/AppCoinTransactionClient.swift
+++ b/Sources/AppCoinsSDK/Models/Services/Transaction/AppCoinTransactionClient.swift
@@ -17,7 +17,13 @@ internal class AppCoinTransactionClient : AppCoinTransactionService {
     
     internal func getBalance(wa: String, result: @escaping (Result<AppCoinBalanceRaw, AppcTransactionError>) -> Void) {
         if let url = URL(string: endpoint + "/wallet/\(wa)/info") {
-            let task = URLSession.shared.dataTask(with: url) { data, response, error in
+            
+            var request = URLRequest(url: url)
+            
+            let userAgent = "AppCoinsWalletIOS/.."
+            request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+            
+            let task = URLSession.shared.dataTask(with: request) { data, response, error in
                 if let error = error {
                     if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
                         result(.failure(.noInternet))

--- a/Sources/AppCoinsSDK/Utils/Utils.swift
+++ b/Sources/AppCoinsSDK/Utils/Utils.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import os
 import Security
 import PPRiskMagnes
+import CommonCrypto
 
 internal struct Utils {
     
@@ -116,5 +117,18 @@ internal struct Utils {
     static func getMagnesSDKClientMetadataID() -> String {
         let magnesResult: MagnesResult = MagnesSDK.shared().collectAndSubmit()
         return magnesResult.getPayPalClientMetaDataId()
+    }
+    
+    static func md5(_ string: String) -> String {
+        let messageData = string.data(using:.utf8)!
+        var digestData = Data(count: Int(CC_MD5_DIGEST_LENGTH))
+        
+        _ = digestData.withUnsafeMutableBytes { digestBytes in
+            messageData.withUnsafeBytes { messageBytes in
+                CC_MD5(messageBytes, CC_LONG(messageData.count), digestBytes)
+            }
+        }
+        
+        return digestData.map { String(format: "%02hhx", $0) }.joined()
     }
 }


### PR DESCRIPTION
**What does this PR do?**

Sets the user agent that identifies a request as coming from the AppCoins SDK for service requests.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] Sources/AppCoinsSDK/Models/Services/Product/AppCoinProductServiceClient.swift

**How should this be manually tested?**

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2804](https://aptoide.atlassian.net/browse/APP-2804)

**Questions:**



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass
