### PR TITLE
Feature/APP-2795 Server IAP Validation

### DIFF
--- a/Sources/AppCoinsSDK/Domain/Entities/Purchase.swift
+++ b/Sources/AppCoinsSDK/Domain/Entities/Purchase.swift
@@ -15,14 +15,38 @@ public class Purchase: Codable {
     public let orderUid: String
     public let payload: String?
     public let created: String
+    public let verification: PurchaseVerification
+
+    public class PurchaseVerification: Codable {
+        public let type: String
+        public let data: PurchaseVerificationData
+        public let signature: String
+        
+        internal init(raw: PurchaseVerificationRaw) {
+            self.type = raw.type
+            self.signature = raw.signature
+            self.data = PurchaseVerificationData(raw: raw.data)
+        }
+    }
     
-    internal init(uid: String, sku: String, state: String, orderUid: String, payload: String?, created: String) {
-        self.uid = uid
-        self.sku = sku
-        self.state = state
-        self.orderUid = orderUid
-        self.payload = payload
-        self.created = created
+    public class PurchaseVerificationData: Codable {
+        public let orderId: String
+        public let packageName: String
+        public let productId: String
+        public let purchaseTime: Int
+        public let purchaseToken: String
+        public let purchaseState: Int
+        public let developerPayload: String
+        
+        internal init(raw: PurchaseVerificationDataRaw) {
+            self.orderId = raw.orderId
+            self.packageName = raw.packageName
+            self.productId = raw.productId
+            self.purchaseTime = raw.purchaseTime
+            self.purchaseToken = raw.purchaseToken
+            self.purchaseState = raw.purchaseState
+            self.developerPayload = raw.developerPayload
+        }
     }
     
     internal init(raw: PurchaseInformationRaw) {
@@ -32,6 +56,7 @@ public class Purchase: Codable {
         self.orderUid = raw.order_uid
         self.payload = raw.payload
         self.created = raw.created
+        self.verification = PurchaseVerification(raw: raw.verification)
     }
     
     internal static func verify(purchaseUID: String, completion: @escaping (Result<Purchase, AppCoinsSDKError>) -> Void ) {

--- a/Sources/AppCoinsSDK/Domain/Repositories/Transaction/TransactionRepository.swift
+++ b/Sources/AppCoinsSDK/Domain/Repositories/Transaction/TransactionRepository.swift
@@ -176,14 +176,13 @@ internal class TransactionRepository: TransactionRepositoryProtocol {
     internal func verifyPurchase(domain: String, uid: String, wa: Wallet, completion: @escaping (Result<Purchase, ProductServiceError>) -> Void) {
         productService.getPurchaseInformation(domain: domain, uid: uid, wa: wa) {
             result in
-            
             switch result {
             case .success(let purchaseRaw):
                 self.productService.getDeveloperPublicKey(domain: domain) {
                     result in
                     switch result {
                     case .success(let publicKeyString):
-                        let verified = self.verifyPurchaseSignature(publicKeyString: publicKeyString, signature: purchaseRaw.verification.signature, message: purchaseRaw.verification.data)
+                        let verified = self.verifyPurchaseSignature(publicKeyString: publicKeyString, signature: purchaseRaw.verification.signature, message: purchaseRaw.verification.originalData)
                         if verified {
                             completion(.success(Purchase(raw: purchaseRaw)))
                         } else {

--- a/Sources/AppCoinsSDK/Models/Raws/GetPurchaseInformationRaw.swift
+++ b/Sources/AppCoinsSDK/Models/Raws/GetPurchaseInformationRaw.swift
@@ -40,7 +40,8 @@ internal struct PurchaseInformationRaw: Codable {
 internal struct PurchaseVerificationRaw: Codable {
     
     internal let type: String
-    internal let data: String
+    internal let data: PurchaseVerificationDataRaw
+    internal let originalData: String
     internal let signature: String
     
     internal enum CodingKeys: String, CodingKey {
@@ -49,4 +50,42 @@ internal struct PurchaseVerificationRaw: Codable {
         case signature = "signature"
     }
     
+    // Custom decoding
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        type = try container.decode(String.self, forKey: .type)
+        
+        // Decode data as string first to preserve the original string
+        originalData = try container.decode(String.self, forKey: .data)
+        
+        // Decode the JSON string into a PurchaseVerificationDataRaw object
+        if let jsonData = originalData.data(using: .utf8) {
+            data = try JSONDecoder().decode(PurchaseVerificationDataRaw.self, from: jsonData)
+        } else {
+            throw DecodingError.dataCorruptedError(forKey: .data, in: container, debugDescription: "Data string is not valid JSON")
+        }
+        
+        signature = try container.decode(String.self, forKey: .signature)
+    }
+}
+
+internal struct PurchaseVerificationDataRaw: Codable {
+    
+    internal let orderId: String
+    internal let packageName: String
+    internal let productId: String
+    internal let purchaseTime: Int
+    internal let purchaseToken: String
+    internal let purchaseState: Int
+    internal let developerPayload: String
+    
+    internal enum CodingKeys: String, CodingKey {
+        case orderId = "orderId"
+        case packageName = "packageName"
+        case productId = "productId"
+        case purchaseTime = "purchaseTime"
+        case purchaseToken = "purchaseToken"
+        case purchaseState = "purchaseState"
+        case developerPayload = "developerPayload"
+    }
 }


### PR DESCRIPTION
**What does this PR do?**

Returns with the purchase object the verification attribute that allows the developer to make the purchase validation himself.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] Sources/AppCoinsSDK/Domain/Entities/Purchase.swift
- [ ] Sources/AppCoinsSDK/Domain/Repositories/Transaction/TransactionRepository.swift
- [ ] Sources/AppCoinsSDK/Models/Raws/GetPurchaseInformationRaw.swift

**How should this be manually tested?**


**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2795](https://aptoide.atlassian.net/browse/APP-2795)

**Questions:**


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass
