### PR TITLE
Feature/APP-2815 Raise Product and Broker services version and set iOS Platform

### DIFF
--- a/Sources/AppCoinsSDK/BuildConfiguration.swift
+++ b/Sources/AppCoinsSDK/BuildConfiguration.swift
@@ -37,9 +37,9 @@ internal class BuildConfiguration {
     static internal var productServiceURL: String {
         switch environment {
             case .debugSDKDev, .releaseSDKDev:
-                return "https://api.dev.catappult.io/productv2/8.20200701"
+                return "https://api.dev.catappult.io/productv2/8.20240812"
             case .debugSDKProd, .releaseSDKProd:
-                return "https://api.catappult.io/productv2/8.20200701"
+                return "https://api.catappult.io/productv2/8.20240812"
         }
     }
     
@@ -73,9 +73,9 @@ internal class BuildConfiguration {
     static internal var billingServiceURL: String {
         switch environment {
             case .debugSDKDev, .releaseSDKDev:
-                return "https://api.dev.catappult.io/broker/8.20200815"
+                return "https://api.dev.catappult.io/broker/8.20240812"
             case .debugSDKProd, .releaseSDKProd:
-                return "https://api.catappult.io/broker/8.20200815"
+                return "https://api.catappult.io/broker/8.20240812"
         }
     }
     

--- a/Sources/AppCoinsSDK/Models/Raws/CreateAPPCTransactionRaw.swift
+++ b/Sources/AppCoinsSDK/Models/Raws/CreateAPPCTransactionRaw.swift
@@ -17,6 +17,7 @@ internal struct CreateAPPCTransactionRaw: Codable {
     internal let type: String
     internal let developerWa: String
     internal let channel: String
+    internal let platform: String
     internal let guestUID: String?
     internal let oemID: String?
     internal let metadata: String?
@@ -31,6 +32,7 @@ internal struct CreateAPPCTransactionRaw: Codable {
         case type = "type"
         case developerWa = "wallets.developer"
         case channel = "channel"
+        case platform = "platform"
         case guestUID = "entity.guest_id"
         case oemID = "entity.oemid"
         case metadata = "metadata"
@@ -41,7 +43,7 @@ internal struct CreateAPPCTransactionRaw: Codable {
         // normalizes the price to adjust to different time zone price syntaxes
         let normalizedPrice = (parameters.appcAmount).replacingOccurrences(of: ",", with: ".")
         
-        return CreateAPPCTransactionRaw(origin: "BDS", domain: parameters.domain, price: normalizedPrice, priceCurrency: "APPC", product: parameters.product, type: "INAPP", developerWa: parameters.developerWa, channel: "IOS", guestUID: parameters.guestUID, oemID: parameters.oemID, metadata: parameters.metadata, reference: parameters.reference
+        return CreateAPPCTransactionRaw(origin: "BDS", domain: parameters.domain, price: normalizedPrice, priceCurrency: "APPC", product: parameters.product, type: "INAPP", developerWa: parameters.developerWa, channel: "IOS", platform: "IOS", guestUID: parameters.guestUID, oemID: parameters.oemID, metadata: parameters.metadata, reference: parameters.reference
         )
     }
     

--- a/Sources/AppCoinsSDK/Models/Raws/CreateAdyenTransactionRaw.swift
+++ b/Sources/AppCoinsSDK/Models/Raws/CreateAdyenTransactionRaw.swift
@@ -18,6 +18,7 @@ internal struct CreateAdyenTransactionRaw: Codable {
     internal let method: String
     internal let developerWa: String
     internal let channel: String
+    internal let platform: String
     internal let paymentChannel: String
     internal let paymentReturnUrl: String?
     internal let userWa: String
@@ -36,6 +37,7 @@ internal struct CreateAdyenTransactionRaw: Codable {
         case method = "method"
         case developerWa = "wallets.developer"
         case channel = "channel"
+        case platform = "platform"
         case paymentChannel = "payment.channel"
         case paymentReturnUrl = "payment.return_url"
         case userWa = "wallets.user"
@@ -54,7 +56,7 @@ internal struct CreateAdyenTransactionRaw: Codable {
             return .success(
                 CreateAdyenTransactionRaw(
                     origin: "BDS", domain: parameters.domain, price: normalizedPrice, priceCurrency: parameters.currency,
-                    product: parameters.product, type: "INAPP", method: method, developerWa: parameters.developerWa, channel: "IOS", paymentChannel: "IOS", paymentReturnUrl: "\(bundleID).iap://api.blockchainds.com/broker", userWa: parameters.userWa, guestUID: parameters.guestUID, oemID: parameters.oemID, metadata: parameters.metadata, reference: parameters.reference
+                    product: parameters.product, type: "INAPP", method: method, developerWa: parameters.developerWa, channel: "IOS", platform: "IOS", paymentChannel: "IOS", paymentReturnUrl: "\(bundleID).iap://api.blockchainds.com/broker", userWa: parameters.userWa, guestUID: parameters.guestUID, oemID: parameters.oemID, metadata: parameters.metadata, reference: parameters.reference
                 )
             )
         } else { return .failure(.failed()) }

--- a/Sources/AppCoinsSDK/Models/Raws/CreateBAPayPalTransactionRaw.swift
+++ b/Sources/AppCoinsSDK/Models/Raws/CreateBAPayPalTransactionRaw.swift
@@ -18,6 +18,7 @@ internal struct CreateBAPayPalTransactionRaw: Codable {
     internal let developerWa: String
     internal let userWa: String
     internal let channel: String
+    internal let platform: String
     internal let guestUID: String?
     internal let oemID: String?
     internal let metadata: String?
@@ -33,6 +34,7 @@ internal struct CreateBAPayPalTransactionRaw: Codable {
         case developerWa = "wallets.developer"
         case userWa = "wallets.user"
         case channel = "channel"
+        case platform = "platform"
         case guestUID = "entity.guest_id"
         case oemID = "entity.oemid"
         case metadata = "metadata"
@@ -44,7 +46,7 @@ internal struct CreateBAPayPalTransactionRaw: Codable {
         let normalizedPrice = parameters.value.replacingOccurrences(of: ",", with: ".")
         
         return CreateBAPayPalTransactionRaw(
-            origin: "BDS", domain: parameters.domain, price: normalizedPrice, priceCurrency: parameters.currency, product: parameters.product, type: "INAPP", developerWa: parameters.developerWa, userWa: parameters.userWa, channel: "IOS", guestUID: parameters.guestUID, oemID: parameters.oemID, metadata: parameters.metadata, reference: parameters.reference
+            origin: "BDS", domain: parameters.domain, price: normalizedPrice, priceCurrency: parameters.currency, product: parameters.product, type: "INAPP", developerWa: parameters.developerWa, userWa: parameters.userWa, channel: "IOS", platform: "IOS", guestUID: parameters.guestUID, oemID: parameters.oemID, metadata: parameters.metadata, reference: parameters.reference
         )
     }
     

--- a/Sources/AppCoinsSDK/Models/Raws/TransferAPPCRaw.swift
+++ b/Sources/AppCoinsSDK/Models/Raws/TransferAPPCRaw.swift
@@ -15,6 +15,7 @@ internal struct TransferAPPCRaw: Codable {
     internal let priceCurrency: String
     internal let type: String
     internal let userWa: String
+    internal let platform: String
     
     internal enum CodingKeys: String, CodingKey {
         case origin = "origin"
@@ -23,11 +24,12 @@ internal struct TransferAPPCRaw: Codable {
         case priceCurrency = "price.currency"
         case type = "type"
         case userWa = "wallets.user"
+        case platform = "platform"
     }
     
     internal static func from(price: String, currency: String, userWa: String) -> TransferAPPCRaw {
         return TransferAPPCRaw (
-            origin: "BDS", domain: BuildConfiguration.appcDomain, price: price, priceCurrency: currency, type: "TRANSFER", userWa: userWa
+            origin: "BDS", domain: BuildConfiguration.appcDomain, price: price, priceCurrency: currency, type: "TRANSFER", userWa: userWa, platform: "IOS"
         )
     }
     

--- a/Sources/AppCoinsSDK/Models/Services/Product/AppCoinProductServiceClient.swift
+++ b/Sources/AppCoinsSDK/Models/Services/Product/AppCoinProductServiceClient.swift
@@ -16,283 +16,329 @@ internal class AppCoinProductServiceClient : AppCoinProductService {
     }
     
     internal func getProductInformation(domain: String, currency: Coin = .EUR, result: @escaping (Result<GetProductInformationRaw, ProductServiceError>) -> Void) {
-        if let url = URL(string: endpoint + "/applications/\(domain)/inapp/consumables?currency=\(currency.rawValue)") {
+        if var urlComponents = URLComponents(string: endpoint) {
+            urlComponents.path += "/applications/\(domain)/inapp/consumables"
+            urlComponents.queryItems = [
+                URLQueryItem(name: "currency", value: currency.rawValue),
+                URLQueryItem(name: "platform", value: "IOS")
+            ]
             
-            var request = URLRequest(url: url)
-            
-            let userAgent = "AppCoinsWalletIOS/.."
-            request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
-            
-            let task = URLSession.shared.dataTask(with: request) { data, response, error in
-                if let error = error {
-                    if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
-                        result(.failure(.noInternet))
+            if let url = urlComponents.url {
+                var request = URLRequest(url: url)
+                
+                let userAgent = "AppCoinsWalletIOS/.."
+                request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+                
+                let task = URLSession.shared.dataTask(with: request) { data, response, error in
+                    if let error = error {
+                        if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
+                            result(.failure(.noInternet))
+                        } else {
+                            result(.failure(.failed))
+                        }
                     } else {
-                        result(.failure(.failed))
-                    }
-                } else {
-                    if let data = data, let findResult = try? JSONDecoder().decode(GetProductInformationRaw.self, from: data) {
-                        result(.success(findResult))
-                    } else {
-                        result(.failure(.failed))
+                        if let data = data, let findResult = try? JSONDecoder().decode(GetProductInformationRaw.self, from: data) {
+                            result(.success(findResult))
+                        } else {
+                            result(.failure(.failed))
+                        }
                     }
                 }
+                task.resume()
             }
-            task.resume()
         }
     }
     
     internal func getProductInformation(domain: String, sku: String, currency: Coin = .EUR, result: @escaping (Result<GetProductInformationRaw, ProductServiceError>) -> Void) {
-        if let url = URL(string: endpoint + "/applications/\(domain)/inapp/consumables/?skus=\(sku)&currency=\(currency.rawValue)") {
+        if var urlComponents = URLComponents(string: endpoint) {
+            urlComponents.path += "/applications/\(domain)/inapp/consumables"
+            urlComponents.queryItems = [
+                URLQueryItem(name: "skus", value: sku),
+                URLQueryItem(name: "currency", value: currency.rawValue),
+                URLQueryItem(name: "platform", value: "IOS")
+            ]
             
-            var request = URLRequest(url: url)
-            
-            let userAgent = "AppCoinsWalletIOS/.."
-            request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
-            
-            let task = URLSession.shared.dataTask(with: request) { data, response, error in
-                if let error = error {
-                    if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
-                        result(.failure(.noInternet))
+            if let url = urlComponents.url {
+                var request = URLRequest(url: url)
+                
+                let userAgent = "AppCoinsWalletIOS/.."
+                request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+                
+                let task = URLSession.shared.dataTask(with: request) { data, response, error in
+                    if let error = error {
+                        if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
+                            result(.failure(.noInternet))
+                        } else {
+                            result(.failure(.failed))
+                        }
                     } else {
-                        result(.failure(.failed))
-                    }
-                } else {
-                    if let data = data, let findResult = try? JSONDecoder().decode(GetProductInformationRaw.self, from: data) {
-                        result(.success(findResult))
-                    } else {
-                        result(.failure(.failed))
+                        if let data = data, let findResult = try? JSONDecoder().decode(GetProductInformationRaw.self, from: data) {
+                            result(.success(findResult))
+                        } else {
+                            result(.failure(.failed))
+                        }
                     }
                 }
+                task.resume()
             }
-            task.resume()
         }
     }
     
     internal func acknowledgePurchase(domain: String, uid: String, wa: Wallet, completion: @escaping (Result<Bool, TransactionError>) -> Void) {
-        let route = "/applications/\(domain)/inapp/purchases/\(uid)/acknowledge"
-        if let url = URL(string: endpoint + route) {
+        if var urlComponents = URLComponents(string: endpoint) {
+            urlComponents.path += "/applications/\(domain)/inapp/purchases/\(uid)/acknowledge"
             
-            var request = URLRequest(url: url)
-            request.httpMethod = "POST"
-            
-            if let ewt = wa.getEWT() {
-                request.setValue(ewt, forHTTPHeaderField: "Authorization")
-            }
-            
-            let userAgent = "AppCoinsWalletIOS/.."
-            request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
-            
-            let task = URLSession.shared.dataTask(with: request) { data, response, error in
-                if let error = error {
-                    if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
-                        completion(.failure(.noInternet))
-                    } else {
-                        completion(.failure(.failed()))
-                    }
-                } else {
-                    if let httpResponse = response as? HTTPURLResponse {
-                        let statusCode = httpResponse.statusCode
-                        if statusCode != 204 {
-                            completion(.failure(.failed()))
+            if let url = urlComponents.url {
+                
+                var request = URLRequest(url: url)
+                request.httpMethod = "POST"
+                
+                if let ewt = wa.getEWT() {
+                    request.setValue(ewt, forHTTPHeaderField: "Authorization")
+                }
+                
+                let userAgent = "AppCoinsWalletIOS/.."
+                request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+                
+                let task = URLSession.shared.dataTask(with: request) { data, response, error in
+                    if let error = error {
+                        if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
+                            completion(.failure(.noInternet))
                         } else {
-                            completion(.success(true))
+                            completion(.failure(.failed()))
+                        }
+                    } else {
+                        if let httpResponse = response as? HTTPURLResponse {
+                            let statusCode = httpResponse.statusCode
+                            if statusCode != 204 {
+                                completion(.failure(.failed()))
+                            } else {
+                                completion(.success(true))
+                            }
                         }
                     }
                 }
+                task.resume()
             }
-            task.resume()
         }
     }
     
     internal func consumePurchase(domain: String, uid: String, wa: Wallet, completion: @escaping (Result<Bool, TransactionError>) -> Void) {
-        let route = "/applications/\(domain)/inapp/purchases/\(uid)/consume"
-        if let url = URL(string: endpoint + route) {
+        if var urlComponents = URLComponents(string: endpoint) {
+            urlComponents.path += "/applications/\(domain)/inapp/purchases/\(uid)/consume"
             
-            var request = URLRequest(url: url)
-            request.httpMethod = "POST"
-            
-            if let ewt = wa.getEWT() {
-                request.setValue(ewt, forHTTPHeaderField: "Authorization")
-            }
-            
-            let userAgent = "AppCoinsWalletIOS/.."
-            request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
-            
-            let task = URLSession.shared.dataTask(with: request) { data, response, error in
-                if let error = error {
-                    if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
-                        completion(.failure(.noInternet))
-                    } else {
-                        completion(.failure(.failed()))
-                    }
-                } else {
-                    if let httpResponse = response as? HTTPURLResponse {
-                        let statusCode = httpResponse.statusCode
-                        if statusCode != 204 {
-                            completion(.failure(.failed()))
+            if let url = urlComponents.url {
+                
+                var request = URLRequest(url: url)
+                request.httpMethod = "POST"
+                
+                if let ewt = wa.getEWT() {
+                    request.setValue(ewt, forHTTPHeaderField: "Authorization")
+                }
+                
+                let userAgent = "AppCoinsWalletIOS/.."
+                request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+                
+                let task = URLSession.shared.dataTask(with: request) { data, response, error in
+                    if let error = error {
+                        if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
+                            completion(.failure(.noInternet))
                         } else {
-                            completion(.success(true))
+                            completion(.failure(.failed()))
+                        }
+                    } else {
+                        if let httpResponse = response as? HTTPURLResponse {
+                            let statusCode = httpResponse.statusCode
+                            if statusCode != 204 {
+                                completion(.failure(.failed()))
+                            } else {
+                                completion(.success(true))
+                            }
                         }
                     }
                 }
+                task.resume()
             }
-            task.resume()
         }
     }
     
     internal func getPurchaseInformation(domain: String, uid: String, wa: Wallet, result: @escaping (Result<PurchaseInformationRaw, ProductServiceError>) -> Void) {
-        let route = "/applications/\(domain)/inapp/consumable/purchases/\(uid)"
-        if let url = URL(string: endpoint + route) {
+        if var urlComponents = URLComponents(string: endpoint) {
+            urlComponents.path += "/applications/\(domain)/inapp/consumable/purchases/\(uid)"
             
-            var request = URLRequest(url: url)
-            
-            if let ewt = wa.getEWT() {
-                request.setValue(ewt, forHTTPHeaderField: "Authorization")
-            }
-            
-            let userAgent = "AppCoinsWalletIOS/.."
-            request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
-            
-            let task = URLSession.shared.dataTask(with: request) { data, response, error in
-                if let error = error {
-                    if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
-                        result(.failure(.noInternet))
+            if let url = urlComponents.url {
+                var request = URLRequest(url: url)
+                
+                if let ewt = wa.getEWT() {
+                    request.setValue(ewt, forHTTPHeaderField: "Authorization")
+                }
+                
+                let userAgent = "AppCoinsWalletIOS/.."
+                request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+                
+                let task = URLSession.shared.dataTask(with: request) { data, response, error in
+                    if let error = error {
+                        if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
+                            result(.failure(.noInternet))
+                        } else {
+                            result(.failure(.failed))
+                        }
                     } else {
-                        result(.failure(.failed))
-                    }
-                } else {
-                    if let data = data, let findResult = try? JSONDecoder().decode(PurchaseInformationRaw.self, from: data) {
-                        result(.success(findResult))
-                    } else {
-                        result(.failure(.failed))
+                        if let data = data, let findResult = try? JSONDecoder().decode(PurchaseInformationRaw.self, from: data) {
+                            result(.success(findResult))
+                        } else {
+                            result(.failure(.failed))
+                        }
                     }
                 }
+                task.resume()
             }
-            task.resume()
         }
     }
     
     internal func getAllPurchases(domain: String, wa: Wallet, result: @escaping (Result<GetPurchasesRaw, ProductServiceError>) -> Void) {
-        let route = "/applications/\(domain)/inapp/consumable/purchases"
-        if let url = URL(string: endpoint + route) {
+        if var urlComponents = URLComponents(string: endpoint) {
+            urlComponents.path += "/applications/\(domain)/inapp/consumable/purchases"
+            urlComponents.queryItems = [
+                URLQueryItem(name: "platform", value: "IOS")
+            ]
             
-            var request = URLRequest(url: url)
-            
-            if let ewt = wa.getEWT() {
-                request.setValue(ewt, forHTTPHeaderField: "Authorization")
-            }
-            
-            let userAgent = "AppCoinsWalletIOS/.."
-            request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
-            
-            let task = URLSession.shared.dataTask(with: request) { data, response, error in
-                if let error = error {
-                    if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
-                        result(.failure(.noInternet))
+            if let url = urlComponents.url {
+                var request = URLRequest(url: url)
+                
+                if let ewt = wa.getEWT() {
+                    request.setValue(ewt, forHTTPHeaderField: "Authorization")
+                }
+                
+                let userAgent = "AppCoinsWalletIOS/.."
+                request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+                
+                let task = URLSession.shared.dataTask(with: request) { data, response, error in
+                    if let error = error {
+                        if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
+                            result(.failure(.noInternet))
+                        } else {
+                            result(.failure(.failed))
+                        }
                     } else {
-                        result(.failure(.failed))
-                    }
-                } else {
-                    if let data = data, let findResult = try? JSONDecoder().decode(GetPurchasesRaw.self, from: data) {
-                        result(.success(findResult))
-                    } else {
-                        result(.failure(.failed))
+                        if let data = data, let findResult = try? JSONDecoder().decode(GetPurchasesRaw.self, from: data) {
+                            result(.success(findResult))
+                        } else {
+                            result(.failure(.failed))
+                        }
                     }
                 }
+                task.resume()
             }
-            task.resume()
         }
     }
     
     internal func getAllPurchasesBySKU(domain: String, sku: String, wa: Wallet, result: @escaping (Result<GetPurchasesRaw, ProductServiceError>) -> Void) {
-        let route = "/applications/\(domain)/inapp/consumable/purchases"
-        if let url = URL(string: endpoint + route + "?sku=\(sku)") {
+        if var urlComponents = URLComponents(string: endpoint) {
+            urlComponents.path += "/applications/\(domain)/inapp/consumable/purchases"
+            urlComponents.queryItems = [
+                URLQueryItem(name: "sku", value: sku),
+                URLQueryItem(name: "platform", value: "IOS")
+            ]
             
-            var request = URLRequest(url: url)
-            
-            if let ewt = wa.getEWT() {
-                request.setValue(ewt, forHTTPHeaderField: "Authorization")
-            }
-            
-            let userAgent = "AppCoinsWalletIOS/.."
-            request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
-            
-            let task = URLSession.shared.dataTask(with: request) { data, response, error in
-                if let error = error {
-                    if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
-                        result(.failure(.noInternet))
+            if let url = urlComponents.url {
+                var request = URLRequest(url: url)
+                
+                if let ewt = wa.getEWT() {
+                    request.setValue(ewt, forHTTPHeaderField: "Authorization")
+                }
+                
+                let userAgent = "AppCoinsWalletIOS/.."
+                request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+                
+                let task = URLSession.shared.dataTask(with: request) { data, response, error in
+                    if let error = error {
+                        if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
+                            result(.failure(.noInternet))
+                        } else {
+                            result(.failure(.failed))
+                        }
                     } else {
-                        result(.failure(.failed))
-                    }
-                } else {
-                    if let data = data, let findResult = try? JSONDecoder().decode(GetPurchasesRaw.self, from: data) {
-                        result(.success(findResult))
-                    } else {
-                        result(.failure(.failed))
+                        if let data = data, let findResult = try? JSONDecoder().decode(GetPurchasesRaw.self, from: data) {
+                            result(.success(findResult))
+                        } else {
+                            result(.failure(.failed))
+                        }
                     }
                 }
+                task.resume()
             }
-            task.resume()
         }
     }
     
     internal func getPurchasesByState(domain: String, state: String, wa: Wallet, result: @escaping (Result<GetPurchasesRaw, ProductServiceError>) -> Void) {
-        let route = "/applications/\(domain)/inapp/consumable/purchases"
-        if let url = URL(string: endpoint + route + "?state=\(state)") {
+        if var urlComponents = URLComponents(string: endpoint) {
+            urlComponents.path += "/applications/\(domain)/inapp/consumable/purchases"
+            urlComponents.queryItems = [
+                URLQueryItem(name: "state", value: state),
+                URLQueryItem(name: "platform", value: "IOS")
+            ]
             
-            var request = URLRequest(url: url)
-            
-            if let ewt = wa.getEWT() {
-                request.setValue(ewt, forHTTPHeaderField: "Authorization")
-            }
-            
-            let userAgent = "AppCoinsWalletIOS/.."
-            request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
-            
-            let task = URLSession.shared.dataTask(with: request) { data, response, error in
-                if let error = error {
-                    if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
-                        result(.failure(.noInternet))
+            if let url = urlComponents.url {
+                var request = URLRequest(url: url)
+                
+                if let ewt = wa.getEWT() {
+                    request.setValue(ewt, forHTTPHeaderField: "Authorization")
+                }
+                
+                let userAgent = "AppCoinsWalletIOS/.."
+                request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+                
+                let task = URLSession.shared.dataTask(with: request) { data, response, error in
+                    if let error = error {
+                        if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
+                            result(.failure(.noInternet))
+                        } else {
+                            result(.failure(.failed))
+                        }
                     } else {
-                        result(.failure(.failed))
-                    }
-                } else {
-                    if let data = data, let findResult = try? JSONDecoder().decode(GetPurchasesRaw.self, from: data) {
-                        result(.success(findResult))
-                    } else {
-                        result(.failure(.failed))
+                        if let data = data, let findResult = try? JSONDecoder().decode(GetPurchasesRaw.self, from: data) {
+                            result(.success(findResult))
+                        } else {
+                            result(.failure(.failed))
+                        }
                     }
                 }
+                task.resume()
             }
-            task.resume()
         }
     }
     
     internal func getDeveloperPublicKey(domain: String, completion: @escaping (Result<String, ProductServiceError>) -> Void) {
-        if let url = URL(string: endpoint + "/applications/\(domain)/public-key") {
+        if var urlComponents = URLComponents(string: endpoint) {
+            urlComponents.path += "/applications/\(domain)/public-key"
+            urlComponents.queryItems = [
+                URLQueryItem(name: "platform", value: "IOS")
+            ]
             
-            var request = URLRequest(url: url)
-            
-            let userAgent = "AppCoinsWalletIOS/.."
-            request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
-            
-            let task = URLSession.shared.dataTask(with: request) { data, response, error in
-                if let error = error {
-                    if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
-                        completion(.failure(.noInternet))
+            if let url = urlComponents.url {
+                var request = URLRequest(url: url)
+                
+                let userAgent = "AppCoinsWalletIOS/.."
+                request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+                
+                let task = URLSession.shared.dataTask(with: request) { data, response, error in
+                    if let error = error {
+                        if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
+                            completion(.failure(.noInternet))
+                        } else {
+                            completion(.failure(.failed))
+                        }
                     } else {
-                        completion(.failure(.failed))
-                    }
-                } else {
-                    if let data = data, let findResult = String(data: data, encoding: .utf8) {
-                        completion(.success(findResult))
-                    } else {
-                        completion(.failure(.failed))
+                        if let data = data, let findResult = String(data: data, encoding: .utf8) {
+                            completion(.success(findResult))
+                        } else {
+                            completion(.failure(.failed))
+                        }
                     }
                 }
+                task.resume()
             }
-            task.resume()
         }
     }
     


### PR DESCRIPTION
**What does this PR do?**

Increases the version number of the Product and Broker services to `8.20240812`.

Includes the `platform` parameter with the value `iOS` in the query string for GET requests and in the body for POST requests on the relevant endpoints.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] Sources/AppCoinsSDK/BuildConfiguration.swift
- [ ] Sources/AppCoinsSDK/Models/Services/Billing/AppCoinBillingClient.swift
- [ ] Sources/AppCoinsSDK/Models/Services/Product/AppCoinProductServiceClient.swift

**How should this be manually tested?**

As this impacts the payment processing endpoints this should be tested in prod to make sure no issues arose from these changes.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2815](https://aptoide.atlassian.net/browse/APP-2815)

**Questions:**



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass
