### PR TITLE
Feature/APP-2794 Sandbox Payments

### DIFF
--- a/Sources/AppCoinsSDK/BuildConfiguration.swift
+++ b/Sources/AppCoinsSDK/BuildConfiguration.swift
@@ -119,7 +119,7 @@ internal class BuildConfiguration {
     
     static internal var userUID =  UIDevice.current.identifierForVendor!.uuidString
     
-    static internal var integratedMethods: [Method] = [.appc, .paypalAdyen, .paypalDirect, .creditCard]
+    static internal var integratedMethods: [Method] = [.appc, .paypalAdyen, .paypalDirect, .creditCard, .sandbox]
     
     static internal var sdkShortVersion: String = "1.2.0"
 }

--- a/Sources/AppCoinsSDK/Domain/Entities/PaymentMethod.swift
+++ b/Sources/AppCoinsSDK/Domain/Entities/PaymentMethod.swift
@@ -38,6 +38,8 @@ internal struct PaymentMethod: Hashable {
         self.fee = raw.fee
         self.disabled = false
     }
+    
+    internal mutating func disable() { self.disabled = true }
 }
 
 internal enum Method: String {
@@ -46,5 +48,6 @@ internal enum Method: String {
     case creditCard = "credit_card"
     case paypalAdyen = "paypal"
     case paypalDirect = "paypal_v2"
+    case sandbox = "sandbox"
     
 }

--- a/Sources/AppCoinsSDK/Domain/Repositories/Transaction/TransactionRepository.swift
+++ b/Sources/AppCoinsSDK/Domain/Repositories/Transaction/TransactionRepository.swift
@@ -34,8 +34,8 @@ internal class TransactionRepository: TransactionRepositoryProtocol {
         }
     }
     
-    internal func getPaymentMethods(value: String, currency: Coin, completion: @escaping (Result<[PaymentMethod], BillingError>) -> Void) {
-        billingService.getPaymentMethods(value: value, currency: currency) {
+    internal func getPaymentMethods(value: String, currency: Coin, wallet: Wallet, domain: String, completion: @escaping (Result<[PaymentMethod], BillingError>) -> Void) {
+        billingService.getPaymentMethods(value: value, currency: currency, wallet: wallet, domain: domain) {
             result in
             
             switch result {
@@ -66,10 +66,6 @@ internal class TransactionRepository: TransactionRepositoryProtocol {
                 completion(.failure(error))
             }
         }
-    }
-    
-    internal func createTransaction(wa: Wallet, raw: CreateAPPCTransactionRaw, completion: @escaping (Result<CreateTransactionResponseRaw, TransactionError>) -> Void) {
-        billingService.createTransaction(wa: wa, raw: raw) { result in completion(result) }
     }
     
     internal func getTransactionInfo(uid: String, wa: Wallet, completion: @escaping (Result<Transaction, TransactionError>) -> Void) {
@@ -215,6 +211,14 @@ internal class TransactionRepository: TransactionRepositoryProtocol {
         } catch {
             return false
         }
+    }
+    
+    internal func createAPPCTransaction(wa: Wallet, raw: CreateAPPCTransactionRaw, completion: @escaping (Result<CreateAPPCTransactionResponseRaw, TransactionError>) -> Void) {
+        billingService.createAPPCTransaction(wa: wa, raw: raw) { result in completion(result) }
+    }
+    
+    internal func createSandboxTransaction(wa: Wallet, raw: CreateSandboxTransactionRaw, completion: @escaping (Result<CreateSandboxTransactionResponseRaw, TransactionError>) -> Void) {
+        billingService.createSandboxTransaction(wa: wa, raw: raw) { result in completion(result) }
     }
     
     internal func createAdyenTransaction(wa: Wallet, raw: CreateAdyenTransactionRaw, completion: @escaping (Result<AdyenTransactionSession, TransactionError>) -> Void) {

--- a/Sources/AppCoinsSDK/Domain/Repositories/Transaction/TransactionRepositoryProtocol.swift
+++ b/Sources/AppCoinsSDK/Domain/Repositories/Transaction/TransactionRepositoryProtocol.swift
@@ -11,11 +11,9 @@ internal protocol TransactionRepositoryProtocol {
     
     func getTransactionBonus(address: String, package_name: String, amount: String, currency: Coin, completion: @escaping (Result<TransactionBonus, TransactionError>) -> Void)
     
-    func getPaymentMethods(value: String, currency: Coin, completion: @escaping (Result<[PaymentMethod], BillingError>) -> Void)
+    func getPaymentMethods(value: String, currency: Coin, wallet: Wallet, domain: String, completion: @escaping (Result<[PaymentMethod], BillingError>) -> Void)
     
     func getDeveloperAddress(package: String, completion: @escaping (Result<String, AptoideServiceError>) -> Void)
-    
-    func createTransaction(wa: Wallet, raw: CreateAPPCTransactionRaw, completion: @escaping (Result<CreateTransactionResponseRaw, TransactionError>) -> Void)
     
     func getTransactionInfo(uid: String, wa: Wallet, completion: @escaping (Result<Transaction, TransactionError>) -> Void)
     
@@ -30,6 +28,10 @@ internal protocol TransactionRepositoryProtocol {
     func consumePurchase(domain: String, uid: String, wa: Wallet, completion: @escaping (Result<Bool, TransactionError>) -> Void)
     
     func verifyPurchase(domain: String, uid: String, wa: Wallet, completion: @escaping (Result<Purchase, ProductServiceError>) -> Void)
+    
+    func createAPPCTransaction(wa: Wallet, raw: CreateAPPCTransactionRaw, completion: @escaping (Result<CreateAPPCTransactionResponseRaw, TransactionError>) -> Void)
+    
+    func createSandboxTransaction(wa: Wallet, raw: CreateSandboxTransactionRaw, completion: @escaping (Result<CreateSandboxTransactionResponseRaw, TransactionError>) -> Void)
     
     func createAdyenTransaction(wa: Wallet, raw: CreateAdyenTransactionRaw, completion: @escaping (Result<AdyenTransactionSession, TransactionError>) -> Void)
     

--- a/Sources/AppCoinsSDK/Domain/UseCases/TransactionUseCases.swift
+++ b/Sources/AppCoinsSDK/Domain/UseCases/TransactionUseCases.swift
@@ -21,16 +21,12 @@ internal class TransactionUseCases {
         repository.getTransactionBonus(address: address, package_name: package_name, amount: amount, currency: currency) { result in completion(result) }
     }
     
-    internal func getPaymentMethods(value: String, currency: Coin, completion: @escaping (Result<[PaymentMethod], BillingError>) -> Void) {
-        repository.getPaymentMethods(value: value, currency: currency) { result in completion(result) }
+    internal func getPaymentMethods(value: String, currency: Coin, wallet: Wallet, domain: String, completion: @escaping (Result<[PaymentMethod], BillingError>) -> Void) {
+        repository.getPaymentMethods(value: value, currency: currency, wallet: wallet, domain: domain) { result in completion(result) }
     }
     
     internal func getDeveloperAddress(package: String, completion: @escaping (Result<String, AptoideServiceError>) -> Void) {
         repository.getDeveloperAddress(package: package) {result in completion(result)}
-    }
-    
-    internal func createTransaction(wa: Wallet, raw: CreateAPPCTransactionRaw, completion: @escaping (Result<CreateTransactionResponseRaw, TransactionError>) -> Void) {
-        repository.createTransaction(wa: wa, raw: raw) {result in completion(result)}
     }
     
     internal func getTransactionInfo(uid: String, wa: Wallet, completion: @escaping (Result<Transaction, TransactionError>) -> Void) {
@@ -59,6 +55,14 @@ internal class TransactionUseCases {
     
     internal func verifyPurchase(domain: String, uid: String, wa: Wallet, completion: @escaping (Result<Purchase, ProductServiceError>) -> Void) {
         repository.verifyPurchase(domain: domain, uid: uid, wa: wa) { result in completion(result) }
+    }
+    
+    internal func createAPPCTransaction(wa: Wallet, raw: CreateAPPCTransactionRaw, completion: @escaping (Result<CreateAPPCTransactionResponseRaw, TransactionError>) -> Void) {
+        repository.createAPPCTransaction(wa: wa, raw: raw) {result in completion(result)}
+    }
+    
+    internal func createSandboxTransaction(wa: Wallet, raw: CreateSandboxTransactionRaw, completion: @escaping (Result<CreateSandboxTransactionResponseRaw, TransactionError>) -> Void) {
+        repository.createSandboxTransaction(wa: wa, raw: raw) {result in completion(result)}
     }
     
     internal func createAdyenTransaction(wa: Wallet, raw: CreateAdyenTransactionRaw, completion: @escaping (Result<AdyenTransactionSession, TransactionError>) -> Void) {

--- a/Sources/AppCoinsSDK/Models/Raws/CreateAPPCTransactionRaw.swift
+++ b/Sources/AppCoinsSDK/Models/Raws/CreateAPPCTransactionRaw.swift
@@ -9,7 +9,6 @@ import Foundation
 
 internal struct CreateAPPCTransactionRaw: Codable {
     
-    internal let origin: String?
     internal let domain: String
     internal let price: String?
     internal let priceCurrency: String
@@ -24,7 +23,6 @@ internal struct CreateAPPCTransactionRaw: Codable {
     internal let reference: String?
     
     internal enum CodingKeys: String, CodingKey {
-        case origin = "origin"
         case domain = "domain"
         case price = "price.value"
         case priceCurrency = "price.currency"
@@ -43,7 +41,7 @@ internal struct CreateAPPCTransactionRaw: Codable {
         // normalizes the price to adjust to different time zone price syntaxes
         let normalizedPrice = (parameters.appcAmount).replacingOccurrences(of: ",", with: ".")
         
-        return CreateAPPCTransactionRaw(origin: "BDS", domain: parameters.domain, price: normalizedPrice, priceCurrency: "APPC", product: parameters.product, type: "INAPP", developerWa: parameters.developerWa, channel: "IOS", platform: "IOS", guestUID: parameters.guestUID, oemID: parameters.oemID, metadata: parameters.metadata, reference: parameters.reference
+        return CreateAPPCTransactionRaw(domain: parameters.domain, price: normalizedPrice, priceCurrency: "APPC", product: parameters.product, type: "INAPP", developerWa: parameters.developerWa, channel: "IOS", platform: "IOS", guestUID: parameters.guestUID, oemID: parameters.oemID, metadata: parameters.metadata, reference: parameters.reference
         )
     }
     
@@ -53,10 +51,10 @@ internal struct CreateAPPCTransactionRaw: Codable {
     
 }
 
-internal struct CreateTransactionResponseRaw: Codable {
+internal struct CreateAPPCTransactionResponseRaw: Codable {
     
     internal let uuid: String
-    internal let status: CreateTransactionStatus
+    internal let status: CreateAPPCTransactionStatus
     internal let hash: String?
     
     internal enum CodingKeys: String, CodingKey {
@@ -67,10 +65,10 @@ internal struct CreateTransactionResponseRaw: Codable {
     
 }
 
-internal enum CreateTransactionStatus: String, Codable {
+internal enum CreateAPPCTransactionStatus: String, Codable {
     
     internal init(from decoder: Decoder) throws {
-        self = try CreateTransactionStatus(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? .UNKNOWN
+        self = try CreateAPPCTransactionStatus(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? .UNKNOWN
     }
     
     case PENDING = "PENDING"
@@ -87,12 +85,12 @@ internal enum CreateTransactionStatus: String, Codable {
     
 }
 
-internal struct CreateTransactionErrorRaw: Codable {
+internal struct CreateAPPCTransactionErrorRaw: Codable {
     
     internal let code: String
     internal let path: String
     internal let text: String
-    internal let data: CreateTransactionErrorDataRaw
+    internal let data: CreateAPPCTransactionErrorDataRaw
     
     internal enum CodingKeys: String, CodingKey {
         case code = "code"
@@ -102,7 +100,7 @@ internal struct CreateTransactionErrorRaw: Codable {
     }
 }
 
-internal struct CreateTransactionErrorDataRaw: Codable {
+internal struct CreateAPPCTransactionErrorDataRaw: Codable {
     
     internal let enduser: String
     internal let technical: String

--- a/Sources/AppCoinsSDK/Models/Raws/CreateAdyenTransactionRaw.swift
+++ b/Sources/AppCoinsSDK/Models/Raws/CreateAdyenTransactionRaw.swift
@@ -9,7 +9,6 @@ import Foundation
 
 internal struct CreateAdyenTransactionRaw: Codable {
     
-    internal let origin: String?
     internal let domain: String
     internal let price: String?
     internal let priceCurrency: String
@@ -28,7 +27,6 @@ internal struct CreateAdyenTransactionRaw: Codable {
     internal let reference: String?
     
     internal enum CodingKeys: String, CodingKey {
-        case origin = "origin"
         case domain = "domain"
         case price = "price.value"
         case priceCurrency = "price.currency"
@@ -55,7 +53,7 @@ internal struct CreateAdyenTransactionRaw: Codable {
         if let method = parameters.method, let bundleID = Bundle.main.bundleIdentifier {
             return .success(
                 CreateAdyenTransactionRaw(
-                    origin: "BDS", domain: parameters.domain, price: normalizedPrice, priceCurrency: parameters.currency,
+                    domain: parameters.domain, price: normalizedPrice, priceCurrency: parameters.currency,
                     product: parameters.product, type: "INAPP", method: method, developerWa: parameters.developerWa, channel: "IOS", platform: "IOS", paymentChannel: "IOS", paymentReturnUrl: "\(bundleID).iap://api.blockchainds.com/broker", userWa: parameters.userWa, guestUID: parameters.guestUID, oemID: parameters.oemID, metadata: parameters.metadata, reference: parameters.reference
                 )
             )

--- a/Sources/AppCoinsSDK/Models/Raws/CreateSandboxTransactionRaw.swift
+++ b/Sources/AppCoinsSDK/Models/Raws/CreateSandboxTransactionRaw.swift
@@ -1,13 +1,13 @@
 //
-//  CreateBAPayPalTransactionRaw.swift
-//  
+//  CreateSandboxTransactionRaw.swift
 //
-//  Created by aptoide on 20/06/2023.
+//
+//  Created by aptoide on 28/08/2024.
 //
 
 import Foundation
 
-internal struct CreateBAPayPalTransactionRaw: Codable {
+internal struct CreateSandboxTransactionRaw: Codable {
     
     internal let domain: String
     internal let price: String?
@@ -15,7 +15,6 @@ internal struct CreateBAPayPalTransactionRaw: Codable {
     internal let product: String?
     internal let type: String
     internal let developerWa: String
-    internal let userWa: String
     internal let channel: String
     internal let platform: String
     internal let guestUID: String?
@@ -30,7 +29,6 @@ internal struct CreateBAPayPalTransactionRaw: Codable {
         case product = "product"
         case type = "type"
         case developerWa = "wallets.developer"
-        case userWa = "wallets.user"
         case channel = "channel"
         case platform = "platform"
         case guestUID = "entity.guest_id"
@@ -39,12 +37,11 @@ internal struct CreateBAPayPalTransactionRaw: Codable {
         case reference = "reference"
     }
     
-    internal static func fromParameters(parameters: TransactionParameters) -> CreateBAPayPalTransactionRaw {
+    internal static func fromParameters(parameters: TransactionParameters) -> CreateSandboxTransactionRaw {
         // normalizes the price to adjust to different time zone price syntaxes
-        let normalizedPrice = parameters.value.replacingOccurrences(of: ",", with: ".")
+        let normalizedPrice = (parameters.appcAmount).replacingOccurrences(of: ",", with: ".")
         
-        return CreateBAPayPalTransactionRaw(
-            domain: parameters.domain, price: normalizedPrice, priceCurrency: parameters.currency, product: parameters.product, type: "INAPP", developerWa: parameters.developerWa, userWa: parameters.userWa, channel: "IOS", platform: "IOS", guestUID: parameters.guestUID, oemID: parameters.oemID, metadata: parameters.metadata, reference: parameters.reference
+        return CreateSandboxTransactionRaw(domain: parameters.domain, price: normalizedPrice, priceCurrency: "APPC", product: parameters.product, type: "INAPP", developerWa: parameters.developerWa, channel: "IOS", platform: "IOS", guestUID: parameters.guestUID, oemID: parameters.oemID, metadata: parameters.metadata, reference: parameters.reference
         )
     }
     
@@ -54,10 +51,10 @@ internal struct CreateBAPayPalTransactionRaw: Codable {
     
 }
 
-internal struct CreateBAPayPalTransactionResponseRaw: Codable {
+internal struct CreateSandboxTransactionResponseRaw: Codable {
     
     internal let uuid: String
-    internal let status: CreateBAPayPalTransactionStatus
+    internal let status: CreateSandboxTransactionStatus
     internal let hash: String?
     
     internal enum CodingKeys: String, CodingKey {
@@ -68,26 +65,10 @@ internal struct CreateBAPayPalTransactionResponseRaw: Codable {
     
 }
 
-internal struct CreateBAPayPalBillingAgreementNotFoundResponseRaw: Codable {
-    
-    internal let code: String
-    internal let path: String?
-    internal let text: String?
-    internal let data: String?
-    
-    internal enum CodingKeys: String, CodingKey {
-        case code = "code"
-        case path = "path"
-        case text = "text"
-        case data = "data"
-    }
-    
-}
-
-internal enum CreateBAPayPalTransactionStatus: String, Codable {
+internal enum CreateSandboxTransactionStatus: String, Codable {
     
     internal init(from decoder: Decoder) throws {
-        self = try CreateBAPayPalTransactionStatus(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? .UNKNOWN
+        self = try CreateSandboxTransactionStatus(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? .UNKNOWN
     }
     
     case PENDING = "PENDING"
@@ -103,3 +84,31 @@ internal enum CreateBAPayPalTransactionStatus: String, Codable {
     case UNKNOWN
     
 }
+
+internal struct CreateSandboxTransactionErrorRaw: Codable {
+    
+    internal let code: String
+    internal let path: String
+    internal let text: String
+    internal let data: CreateSandboxTransactionErrorDataRaw
+    
+    internal enum CodingKeys: String, CodingKey {
+        case code = "code"
+        case path = "path"
+        case text = "text"
+        case data = "data"
+    }
+}
+
+internal struct CreateSandboxTransactionErrorDataRaw: Codable {
+    
+    internal let enduser: String
+    internal let technical: String
+    
+    internal enum CodingKeys: String, CodingKey {
+        case enduser = "enduser"
+        case technical = "technical"
+    }
+    
+}
+

--- a/Sources/AppCoinsSDK/Models/Raws/TransferAPPCRaw.swift
+++ b/Sources/AppCoinsSDK/Models/Raws/TransferAPPCRaw.swift
@@ -9,7 +9,6 @@ import Foundation
 
 internal struct TransferAPPCRaw: Codable {
     
-    internal let origin: String?
     internal let domain: String
     internal let price: String?
     internal let priceCurrency: String
@@ -18,7 +17,6 @@ internal struct TransferAPPCRaw: Codable {
     internal let platform: String
     
     internal enum CodingKeys: String, CodingKey {
-        case origin = "origin"
         case domain = "domain"
         case price = "price.value"
         case priceCurrency = "price.currency"
@@ -29,7 +27,7 @@ internal struct TransferAPPCRaw: Codable {
     
     internal static func from(price: String, currency: String, userWa: String) -> TransferAPPCRaw {
         return TransferAPPCRaw (
-            origin: "BDS", domain: BuildConfiguration.appcDomain, price: price, priceCurrency: currency, type: "TRANSFER", userWa: userWa, platform: "IOS"
+            domain: BuildConfiguration.appcDomain, price: price, priceCurrency: currency, type: "TRANSFER", userWa: userWa, platform: "IOS"
         )
     }
     
@@ -41,13 +39,61 @@ internal struct TransferAPPCRaw: Codable {
 internal struct TransferAPPCResponseRaw: Codable {
     
     internal let uuid: String
-    internal let status: CreateTransactionStatus
+    internal let status: TransferAPPCTransactionStatus
     internal let hash: String?
     
     internal enum CodingKeys: String, CodingKey {
         case uuid = "uid"
         case status = "status"
         case hash = "hash"
+    }
+    
+}
+
+internal enum TransferAPPCTransactionStatus: String, Codable {
+    
+    internal init(from decoder: Decoder) throws {
+        self = try TransferAPPCTransactionStatus(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? .UNKNOWN
+    }
+    
+    case PENDING = "PENDING"
+    case PENDING_SERVICE_AUTHORIZATION = "PENDING_SERVICE_AUTHORIZATION"
+    case PROCESSING = "PROCESSING"
+    case COMPLETED = "COMPLETED"
+    case PENDING_USER_PAYMENT = "PENDING_USER_PAYMENT"
+    case INVALID_TRANSACTION = "INVALID_TRANSACTION"
+    case FAILED = "FAILED"
+    case CANCELED = "CANCELED"
+    case FRAUD = "FRAUD"
+    case SETTLED = "SETTLED"
+    case UNKNOWN
+    
+}
+
+
+internal struct TransferAPPCTransactionErrorRaw: Codable {
+    
+    internal let code: String
+    internal let path: String
+    internal let text: String
+    internal let data: TransferAPPCTransactionErrorDataRaw
+    
+    internal enum CodingKeys: String, CodingKey {
+        case code = "code"
+        case path = "path"
+        case text = "text"
+        case data = "data"
+    }
+}
+
+internal struct TransferAPPCTransactionErrorDataRaw: Codable {
+    
+    internal let enduser: String
+    internal let technical: String
+    
+    internal enum CodingKeys: String, CodingKey {
+        case enduser = "enduser"
+        case technical = "technical"
     }
     
 }

--- a/Sources/AppCoinsSDK/Models/Services/Billing/AppCoinBillingClient.swift
+++ b/Sources/AppCoinsSDK/Models/Services/Billing/AppCoinBillingClient.swift
@@ -41,7 +41,6 @@ internal class AppCoinBillingClient : AppCoinBillingService {
                             result(.success(convertion))
                         } else { result(.failure(.failed)) }
                     }
-                    
                 }
                 task.resume()
             }
@@ -78,7 +77,6 @@ internal class AppCoinBillingClient : AppCoinBillingService {
                             result(.success(convertion))
                         } else { result(.failure(.failed)) }
                     }
-                    
                 }
                 task.resume()
             }
@@ -132,8 +130,6 @@ internal class AppCoinBillingClient : AppCoinBillingService {
                                 completion(.failure(.general))
                             }
                         }
-                        
-                        
                     })
                     task.resume()
                 }
@@ -228,8 +224,6 @@ internal class AppCoinBillingClient : AppCoinBillingService {
                                 completion(.failure(.general))
                             }
                         }
-                        
-                        
                     })
                     task.resume()
                 }
@@ -280,8 +274,6 @@ internal class AppCoinBillingClient : AppCoinBillingService {
                                 completion(.failure(.general))
                             }
                         }
-                        
-                        
                     })
                     task.resume()
                 }
@@ -370,7 +362,6 @@ internal class AppCoinBillingClient : AppCoinBillingService {
                             }
                         } else {
                             if let data = data {
-                                print(String(data: data, encoding: .utf8))
                                 if let successResponse = try? JSONDecoder().decode(CreateBAPayPalTransactionResponseRaw.self, from: data) {
                                     completion(.success(successResponse))
                                 } else if let BANotFounResponse = try? JSONDecoder().decode(CreateBAPayPalBillingAgreementNotFoundResponseRaw.self, from: data) {
@@ -386,8 +377,6 @@ internal class AppCoinBillingClient : AppCoinBillingService {
                                 completion(.failure(.failed()))
                             }
                         }
-                        
-                        
                     })
                     task.resume()
                 }

--- a/Sources/AppCoinsSDK/Models/Services/Billing/AppCoinBillingClient.swift
+++ b/Sources/AppCoinsSDK/Models/Services/Billing/AppCoinBillingClient.swift
@@ -48,11 +48,13 @@ internal class AppCoinBillingClient : AppCoinBillingService {
         }
     }
     
-    internal func getPaymentMethods(value: String, currency: Coin, result: @escaping (Result<GetPaymentMethodsRaw, BillingError>) -> Void) {
+    internal func getPaymentMethods(value: String, currency: Coin, wallet: Wallet, domain: String, result: @escaping (Result<GetPaymentMethodsRaw, BillingError>) -> Void) {
         
         if var urlComponents = URLComponents(string: endpoint) {
             urlComponents.path += "/methods"
             urlComponents.queryItems = [
+                URLQueryItem(name: "domain", value: domain),
+                URLQueryItem(name: "wallet.address", value: wallet.getWalletAddress()),
                 URLQueryItem(name: "price.value", value: value),
                 URLQueryItem(name: "price.currency", value: currency.rawValue),
                 URLQueryItem(name: "channel", value: "IOS")
@@ -79,58 +81,6 @@ internal class AppCoinBillingClient : AppCoinBillingService {
                     
                 }
                 task.resume()
-            }
-        }
-    }
-
-    internal func createTransaction(wa: Wallet, raw: CreateAPPCTransactionRaw, completion: @escaping (Result<CreateTransactionResponseRaw, TransactionError>) -> Void) {
-        
-        if var urlComponents = URLComponents(string: endpoint) {
-            urlComponents.path += "/gateways/appcoins_credits/transactions"
-            
-            if let url = urlComponents.url {
-                if let body = raw.toJSON() {
-                    var request = URLRequest(url: url)
-                    request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-                    request.httpBody = body
-                    request.httpMethod = "POST"
-                    
-                    let userAgent = "AppCoinsWalletIOS/.."
-                    request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
-                    
-                    if let ewt = wa.getEWT() {
-                        request.setValue(ewt, forHTTPHeaderField: "Authorization")
-                    }
-                    
-                    // Right now not giving feedback on different types of errors
-                    let task = URLSession.shared.dataTask(with: request, completionHandler: { data, response, error in
-                        
-                        if let error = error {
-                            if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
-                                completion(.failure(.noInternet))
-                            } else {
-                                completion(.failure(.failed()))
-                            }
-                        } else {
-                            if let data = data {
-                                if let txResponse = try? JSONDecoder().decode(CreateTransactionResponseRaw.self, from: data) {
-                                    completion(.success(txResponse))
-                                } else {
-                                    if let errorResponse = try? JSONDecoder().decode(CreateTransactionErrorRaw.self, from: data) {
-                                        completion(.failure(.failed(description: errorResponse.data.enduser)))
-                                    } else {
-                                        completion(.failure(.general))
-                                    }
-                                }
-                            } else {
-                                completion(.failure(.general))
-                            }
-                        }
-                        
-                        
-                    })
-                    task.resume()
-                }
             }
         }
     }
@@ -172,7 +122,7 @@ internal class AppCoinBillingClient : AppCoinBillingService {
                                 if let txResponse = try? JSONDecoder().decode(TransferAPPCResponseRaw.self, from: data) {
                                     completion(.success(txResponse))
                                 } else {
-                                    if let errorResponse = try? JSONDecoder().decode(CreateTransactionErrorRaw.self, from: data) {
+                                    if let errorResponse = try? JSONDecoder().decode(TransferAPPCTransactionErrorRaw.self, from: data) {
                                         completion(.failure(.failed(description: errorResponse.data.enduser)))
                                     } else {
                                         completion(.failure(.general))
@@ -231,6 +181,110 @@ internal class AppCoinBillingClient : AppCoinBillingService {
                     }
                 }
                 task.resume()
+            }
+        }
+    }
+    
+    internal func createAPPCTransaction(wa: Wallet, raw: CreateAPPCTransactionRaw, completion: @escaping (Result<CreateAPPCTransactionResponseRaw, TransactionError>) -> Void) {
+        
+        if var urlComponents = URLComponents(string: endpoint) {
+            urlComponents.path += "/gateways/appcoins_credits/transactions"
+            
+            if let url = urlComponents.url {
+                if let body = raw.toJSON() {
+                    var request = URLRequest(url: url)
+                    request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+                    request.httpBody = body
+                    request.httpMethod = "POST"
+                    
+                    let userAgent = "AppCoinsWalletIOS/.."
+                    request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+                    
+                    if let ewt = wa.getEWT() {
+                        request.setValue(ewt, forHTTPHeaderField: "Authorization")
+                    }
+                    
+                    // Right now not giving feedback on different types of errors
+                    let task = URLSession.shared.dataTask(with: request, completionHandler: { data, response, error in
+                        
+                        if let error = error {
+                            if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
+                                completion(.failure(.noInternet))
+                            } else {
+                                completion(.failure(.failed()))
+                            }
+                        } else {
+                            if let data = data {
+                                if let txResponse = try? JSONDecoder().decode(CreateAPPCTransactionResponseRaw.self, from: data) {
+                                    completion(.success(txResponse))
+                                } else {
+                                    if let errorResponse = try? JSONDecoder().decode(CreateAPPCTransactionErrorRaw.self, from: data) {
+                                        completion(.failure(.failed(description: errorResponse.data.enduser)))
+                                    } else {
+                                        completion(.failure(.general))
+                                    }
+                                }
+                            } else {
+                                completion(.failure(.general))
+                            }
+                        }
+                        
+                        
+                    })
+                    task.resume()
+                }
+            }
+        }
+    }
+    
+    internal func createSandboxTransaction(wa: Wallet, raw: CreateSandboxTransactionRaw, completion: @escaping (Result<CreateSandboxTransactionResponseRaw, TransactionError>) -> Void) {
+        
+        if var urlComponents = URLComponents(string: endpoint) {
+            urlComponents.path += "/gateways/sandbox/transactions"
+            
+            if let url = urlComponents.url {
+                if let body = raw.toJSON() {
+                    var request = URLRequest(url: url)
+                    request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+                    request.httpBody = body
+                    request.httpMethod = "POST"
+                    
+                    let userAgent = "AppCoinsWalletIOS/.."
+                    request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+                    
+                    if let ewt = wa.getEWT() {
+                        request.setValue(ewt, forHTTPHeaderField: "Authorization")
+                    }
+                    
+                    // Right now not giving feedback on different types of errors
+                    let task = URLSession.shared.dataTask(with: request, completionHandler: { data, response, error in
+                        
+                        if let error = error {
+                            if let nsError = error as NSError?, nsError.code == NSURLErrorNotConnectedToInternet {
+                                completion(.failure(.noInternet))
+                            } else {
+                                completion(.failure(.failed()))
+                            }
+                        } else {
+                            if let data = data {
+                                if let txResponse = try? JSONDecoder().decode(CreateSandboxTransactionResponseRaw.self, from: data) {
+                                    completion(.success(txResponse))
+                                } else {
+                                    if let errorResponse = try? JSONDecoder().decode(CreateSandboxTransactionErrorRaw.self, from: data) {
+                                        completion(.failure(.failed(description: errorResponse.data.enduser)))
+                                    } else {
+                                        completion(.failure(.general))
+                                    }
+                                }
+                            } else {
+                                completion(.failure(.general))
+                            }
+                        }
+                        
+                        
+                    })
+                    task.resume()
+                }
             }
         }
     }
@@ -316,6 +370,7 @@ internal class AppCoinBillingClient : AppCoinBillingService {
                             }
                         } else {
                             if let data = data {
+                                print(String(data: data, encoding: .utf8))
                                 if let successResponse = try? JSONDecoder().decode(CreateBAPayPalTransactionResponseRaw.self, from: data) {
                                     completion(.success(successResponse))
                                 } else if let BANotFounResponse = try? JSONDecoder().decode(CreateBAPayPalBillingAgreementNotFoundResponseRaw.self, from: data) {

--- a/Sources/AppCoinsSDK/Models/Services/Billing/AppCoinBillingService.swift
+++ b/Sources/AppCoinsSDK/Models/Services/Billing/AppCoinBillingService.swift
@@ -9,15 +9,17 @@ import Foundation
 
 internal protocol AppCoinBillingService {
     
-    func createTransaction(wa: Wallet, raw: CreateAPPCTransactionRaw, completion: @escaping (Result<CreateTransactionResponseRaw, TransactionError>) -> Void)
-    
-    func getPaymentMethods(value: String, currency: Coin, result: @escaping (Result<GetPaymentMethodsRaw, BillingError>) -> Void)
+    func getPaymentMethods(value: String, currency: Coin, wallet: Wallet, domain: String, result: @escaping (Result<GetPaymentMethodsRaw, BillingError>) -> Void)
     
     func convertCurrency(money: String, fromCurrency: Coin, toCurrency: Coin, result: @escaping (Result<ConvertCurrencyRaw, BillingError>) -> Void)
     
     func transferAPPC(wa: Wallet, raw: TransferAPPCRaw, completion: @escaping (Result<TransferAPPCResponseRaw, TransactionError>) -> Void)
     
     func getTransactionInfo(uid: String, wa: Wallet, completion: @escaping (Result<GetTransactionInfoRaw, TransactionError>) -> Void)
+    
+    func createAPPCTransaction(wa: Wallet, raw: CreateAPPCTransactionRaw, completion: @escaping (Result<CreateAPPCTransactionResponseRaw, TransactionError>) -> Void)
+    
+    func createSandboxTransaction(wa: Wallet, raw: CreateSandboxTransactionRaw, completion: @escaping (Result<CreateSandboxTransactionResponseRaw, TransactionError>) -> Void)
     
     func createAdyenTransaction(wa: Wallet, raw: CreateAdyenTransactionRaw, completion: @escaping (Result<CreateAdyenTransactionResponseRaw, TransactionError>) -> Void)
     

--- a/Sources/AppCoinsSDK/UI/Purchase/ViewModels/BottomSheetViewModel.swift
+++ b/Sources/AppCoinsSDK/UI/Purchase/ViewModels/BottomSheetViewModel.swift
@@ -166,6 +166,9 @@ internal class BottomSheetViewModel : ObservableObject {
             case Method.paypalDirect.rawValue:
                 DispatchQueue.main.async { self.purchaseState = .processing }
                 self.buyWithPayPalDirect()
+            case Method.sandbox.rawValue:
+                DispatchQueue.main.async { self.purchaseState = .processing }
+                self.buyWithSandbox()
             default:
                 self.transactionFailedWith(error: .systemError)
             }
@@ -181,12 +184,42 @@ internal class BottomSheetViewModel : ObservableObject {
                 
                 switch result {
                 case .success(let wallet):
-                    self.transactionUseCases.createTransaction(wa: wallet, raw: raw) {
+                    self.transactionUseCases.createAPPCTransaction(wa: wallet, raw: raw) {
                         result in
                         
                         switch result {
                         case .success(let transactionResponse):
                             self.finishPurchase(transactionUuid: transactionResponse.uuid, method: .appc)
+                        case .failure(let error):
+                            switch error {
+                            case .failed(let description): self.transactionFailedWith(error: .systemError, description: description)
+                            case .noInternet: self.transactionFailedWith(error: .networkError)
+                            default: self.transactionFailedWith(error: .systemError)
+                            }
+                        }
+                    }
+                case .failure(_):
+                    self.transactionFailedWith(error: .notEntitled)
+                }
+            }
+        } else { self.transactionFailedWith(error: .systemError) }
+    }
+    
+    internal func buyWithSandbox() {
+        if let parameters = TransactionViewModel.shared.transactionParameters {
+            let raw = CreateSandboxTransactionRaw.fromParameters(parameters: parameters)
+            
+            self.walletUseCases.getWallet() {
+                result in
+                
+                switch result {
+                case .success(let wallet):
+                    self.transactionUseCases.createSandboxTransaction(wa: wallet, raw: raw) {
+                        result in
+                        
+                        switch result {
+                        case .success(let transactionResponse):
+                            self.finishPurchase(transactionUuid: transactionResponse.uuid, method: .sandbox)
                         case .failure(let error):
                             switch error {
                             case .failed(let description): self.transactionFailedWith(error: .systemError, description: description)

--- a/Sources/AppCoinsSDK/UI/Purchase/ViewModels/TransactionViewModel.swift
+++ b/Sources/AppCoinsSDK/UI/Purchase/ViewModels/TransactionViewModel.swift
@@ -76,7 +76,7 @@ internal class TransactionViewModel : ObservableObject {
                             transactionBonus in
                             
                                 // 3. Get payment methods available
-                                self.getPaymentMethods(value: product.priceValue, currency: productCurrency) {
+                                self.getPaymentMethods(value: product.priceValue, currency: productCurrency, wallet: wallet, domain: domain) {
                                     availablePaymentMethods in
 
                                     // 4. Get user's balance
@@ -147,8 +147,8 @@ internal class TransactionViewModel : ObservableObject {
         }
     }
     
-    private func getPaymentMethods(value: String, currency: Coin, completion: @escaping ([PaymentMethod]) -> Void) {
-        self.transactionUseCases.getPaymentMethods(value: value, currency: currency) {
+    private func getPaymentMethods(value: String, currency: Coin, wallet: Wallet, domain: String, completion: @escaping ([PaymentMethod]) -> Void) {
+        self.transactionUseCases.getPaymentMethods(value: value, currency: currency, wallet: wallet, domain: domain) {
             result in
             
             switch result {
@@ -192,90 +192,161 @@ internal class TransactionViewModel : ObservableObject {
         }
     }
     
+//    private func showPaymentMethodsOnBuild(balance: Balance) {
+//        // Other Payment Methods filtering
+//        if balance.appcoinsBalance < self.transaction?.appcAmount ?? 0 {
+//            if let index = self.transaction?.paymentMethods.firstIndex(where: { $0.name == Method.appc.rawValue }) {
+//                if var appcPM = self.transaction?.paymentMethods.remove(at: index) {
+//                    appcPM.disabled = true
+//                    self.transaction?.paymentMethods.append(appcPM)
+//                }
+//            }
+//        }
+//        
+//        // Quick view of last payment method used
+//        let lastPaymentMethod = self.transactionUseCases.getLastPaymentMethod()
+//        if let lastPaymentMethod = lastPaymentMethod {
+//            switch lastPaymentMethod {
+//            case Method.appc:
+//                if let appcPM = self.transaction?.paymentMethods.first(where: { $0.name == Method.appc.rawValue && $0.disabled == false }) {
+//                    self.lastPaymentMethod = appcPM
+//                    self.paymentMethodSelected = appcPM
+//                } else {
+//                    if let paypal = self.transaction?.paymentMethods.first(where: { $0.name == Method.paypalAdyen.rawValue || $0.name == Method.paypalDirect.rawValue }) {
+//                        self.paymentMethodSelected = paypal
+//                    } else if let selected = self.transaction?.paymentMethods.first {
+//                        self.paymentMethodSelected = selected
+//                    }
+//                    self.showOtherPaymentMethods = true
+//                }
+//            case Method.paypalAdyen:
+//                if let paypalPM = self.transaction?.paymentMethods.first(where: { $0.name == Method.paypalAdyen.rawValue }) {
+//                    self.lastPaymentMethod = paypalPM
+//                    self.paymentMethodSelected = paypalPM
+//                } else {
+//                    if let paypal = self.transaction?.paymentMethods.first(where: { $0.name == Method.paypalAdyen.rawValue || $0.name == Method.paypalDirect.rawValue }) {
+//                        self.paymentMethodSelected = paypal
+//                    } else if let selected = self.transaction?.paymentMethods.first {
+//                        self.paymentMethodSelected = selected
+//                    }
+//                    self.showOtherPaymentMethods = true
+//                }
+//            case Method.paypalDirect:
+//                if let paypalPM = self.transaction?.paymentMethods.first(where: { $0.name == Method.paypalDirect.rawValue }) {
+//                    if self.transactionUseCases.hasBillingAgreement() { self.paypalLogOut = true }
+//                    self.lastPaymentMethod = paypalPM
+//                    self.paymentMethodSelected = paypalPM
+//                } else {
+//                    if let paypal = self.transaction?.paymentMethods.first(where: { $0.name == Method.paypalAdyen.rawValue || $0.name == Method.paypalDirect.rawValue }) {
+//                        self.paymentMethodSelected = paypal
+//                    } else if let selected = self.transaction?.paymentMethods.first {
+//                        self.paymentMethodSelected = selected
+//                    }
+//                    self.showOtherPaymentMethods = true
+//                }
+//            case Method.creditCard:
+//                if let ccPM = self.transaction?.paymentMethods.first(where: { $0.name == Method.creditCard.rawValue }) {
+//                    self.lastPaymentMethod = ccPM
+//                    self.paymentMethodSelected = ccPM
+//                } else {
+//                    if let paypal = self.transaction?.paymentMethods.first(where: { $0.name == Method.paypalAdyen.rawValue || $0.name == Method.paypalDirect.rawValue }) {
+//                        self.paymentMethodSelected = paypal
+//                    } else if let selected = self.transaction?.paymentMethods.first {
+//                        self.paymentMethodSelected = selected
+//                    }
+//                    self.showOtherPaymentMethods = true
+//                }
+//            case Method.sandbox:
+//                if let sandboxPM = self.transaction?.paymentMethods.first(where: { $0.name == Method.sandbox.rawValue }) {
+//                    self.lastPaymentMethod = sandboxPM
+//                    self.paymentMethodSelected = sandboxPM
+//                } else {
+//                    if let paypal = self.transaction?.paymentMethods.first(where: { $0.name == Method.paypalAdyen.rawValue || $0.name == Method.paypalDirect.rawValue }) {
+//                        self.paymentMethodSelected = paypal
+//                    } else if let selected = self.transaction?.paymentMethods.first {
+//                        self.paymentMethodSelected = selected
+//                    }
+//                    self.showOtherPaymentMethods = true
+//                }
+//            default:
+//                if let paypal = self.transaction?.paymentMethods.first(where: { $0.name == Method.paypalAdyen.rawValue || $0.name == Method.paypalDirect.rawValue }) {
+//                    self.paymentMethodSelected = paypal
+//                } else if let selected = self.transaction?.paymentMethods.first {
+//                    self.paymentMethodSelected = selected
+//                }
+//                self.showOtherPaymentMethods = true
+//            }
+//        } else {
+//            if let appcPM = self.transaction?.paymentMethods.first(where: { $0.name == Method.appc.rawValue && $0.disabled == false }) {
+//                self.lastPaymentMethod = appcPM
+//                self.paymentMethodSelected = appcPM
+//            } else {
+//                if let paypal = self.transaction?.paymentMethods.first(where: { $0.name == Method.paypalAdyen.rawValue || $0.name == Method.paypalDirect.rawValue }) {
+//                    self.paymentMethodSelected = paypal
+//                } else if let selected = self.transaction?.paymentMethods.first {
+//                    self.paymentMethodSelected = selected
+//                }
+//                self.showOtherPaymentMethods = true
+//            }
+//        }
+//    }
+    
     private func showPaymentMethodsOnBuild(balance: Balance) {
-        // Other Payment Methods filtering
-        if balance.appcoinsBalance < self.transaction?.appcAmount ?? 0 {
-            if let index = self.transaction?.paymentMethods.firstIndex(where: { $0.name == Method.appc.rawValue }) {
-                if var appcPM = self.transaction?.paymentMethods.remove(at: index) {
-                    appcPM.disabled = true
-                    self.transaction?.paymentMethods.append(appcPM)
-                }
+        // Filter out the AppCoins payment method if balance is insufficient
+        disableAppCoinsIfNeeded(balance: balance)
+        
+        // Quick view of the last payment method used
+        if let lastPaymentMethod = self.transactionUseCases.getLastPaymentMethod() {
+            showQuickPaymentMethod(lastPaymentMethod)
+        } else {
+            selectDefaultPaymentMethod()
+        }
+    }
+
+    private func disableAppCoinsIfNeeded(balance: Balance) {
+        if balance.appcoinsBalance < self.transaction?.appcAmount ?? 0,
+           let index = self.transaction?.paymentMethods.firstIndex(where: { $0.name == Method.appc.rawValue }) {
+            if var appcPaymentMethod = self.transaction?.paymentMethods[index] {
+                appcPaymentMethod.disable()
+                self.transaction?.paymentMethods[index] = appcPaymentMethod
             }
         }
-        
-        // Quick view of last payment method used
-        let lastPaymentMethod = self.transactionUseCases.getLastPaymentMethod()
-        if let lastPaymentMethod = lastPaymentMethod {
-            switch lastPaymentMethod {
-            case Method.appc:
-                if let appcPM = self.transaction?.paymentMethods.first(where: { $0.name == Method.appc.rawValue && $0.disabled == false }) {
-                    self.lastPaymentMethod = appcPM
-                    self.paymentMethodSelected = appcPM
-                } else {
-                    if let paypal = self.transaction?.paymentMethods.first(where: { $0.name == Method.paypalAdyen.rawValue || $0.name == Method.paypalDirect.rawValue }) {
-                        self.paymentMethodSelected = paypal
-                    } else if let selected = self.transaction?.paymentMethods.first {
-                        self.paymentMethodSelected = selected
-                    }
-                    self.showOtherPaymentMethods = true
-                }
-            case Method.paypalAdyen:
-                if let paypalPM = self.transaction?.paymentMethods.first(where: { $0.name == Method.paypalAdyen.rawValue }) {
-                    self.lastPaymentMethod = paypalPM
-                    self.paymentMethodSelected = paypalPM
-                } else {
-                    if let paypal = self.transaction?.paymentMethods.first(where: { $0.name == Method.paypalAdyen.rawValue || $0.name == Method.paypalDirect.rawValue }) {
-                        self.paymentMethodSelected = paypal
-                    } else if let selected = self.transaction?.paymentMethods.first {
-                        self.paymentMethodSelected = selected
-                    }
-                    self.showOtherPaymentMethods = true
-                }
-            case Method.paypalDirect:
-                if let paypalPM = self.transaction?.paymentMethods.first(where: { $0.name == Method.paypalDirect.rawValue }) {
-                    if self.transactionUseCases.hasBillingAgreement() { self.paypalLogOut = true }
-                    self.lastPaymentMethod = paypalPM
-                    self.paymentMethodSelected = paypalPM
-                } else {
-                    if let paypal = self.transaction?.paymentMethods.first(where: { $0.name == Method.paypalAdyen.rawValue || $0.name == Method.paypalDirect.rawValue }) {
-                        self.paymentMethodSelected = paypal
-                    } else if let selected = self.transaction?.paymentMethods.first {
-                        self.paymentMethodSelected = selected
-                    }
-                    self.showOtherPaymentMethods = true
-                }
-            case Method.creditCard:
-                if let ccPM = self.transaction?.paymentMethods.first(where: { $0.name == Method.creditCard.rawValue }) {
-                    self.lastPaymentMethod = ccPM
-                    self.paymentMethodSelected = ccPM
-                } else {
-                    if let paypal = self.transaction?.paymentMethods.first(where: { $0.name == Method.paypalAdyen.rawValue || $0.name == Method.paypalDirect.rawValue }) {
-                        self.paymentMethodSelected = paypal
-                    } else if let selected = self.transaction?.paymentMethods.first {
-                        self.paymentMethodSelected = selected
-                    }
-                    self.showOtherPaymentMethods = true
-                }
-            default:
-                if let paypal = self.transaction?.paymentMethods.first(where: { $0.name == Method.paypalAdyen.rawValue || $0.name == Method.paypalDirect.rawValue }) {
-                    self.paymentMethodSelected = paypal
-                } else if let selected = self.transaction?.paymentMethods.first {
-                    self.paymentMethodSelected = selected
-                }
-                self.showOtherPaymentMethods = true
-            }
+    }
+
+    private func showQuickPaymentMethod(_ lastPaymentMethod: Method) {
+        if let selectedMethod = self.transaction?.paymentMethods.first(where: { $0.name == lastPaymentMethod.rawValue && !$0.disabled }) {
+            self.lastPaymentMethod = selectedMethod
+            self.paymentMethodSelected = selectedMethod
         } else {
-            if let appcPM = self.transaction?.paymentMethods.first(where: { $0.name == Method.appc.rawValue && $0.disabled == false }) {
-                self.lastPaymentMethod = appcPM
-                self.paymentMethodSelected = appcPM
-            } else {
-                if let paypal = self.transaction?.paymentMethods.first(where: { $0.name == Method.paypalAdyen.rawValue || $0.name == Method.paypalDirect.rawValue }) {
-                    self.paymentMethodSelected = paypal
-                } else if let selected = self.transaction?.paymentMethods.first {
-                    self.paymentMethodSelected = selected
-                }
-                self.showOtherPaymentMethods = true
-            }
+            handleFallbackPaymentMethod(for: lastPaymentMethod)
+        }
+    }
+
+    private func handleFallbackPaymentMethod(for method: Method) {
+        if let fallback = findFallbackPaymentMethod() {
+            self.paymentMethodSelected = fallback
+        }
+        
+        if method == .paypalDirect, self.transactionUseCases.hasBillingAgreement() {
+            self.paypalLogOut = true
+        }
+        
+        self.showOtherPaymentMethods = true
+    }
+
+    private func findFallbackPaymentMethod() -> PaymentMethod? {
+        return self.transaction?.paymentMethods.first(where: {
+            $0.name == Method.paypalAdyen.rawValue || $0.name == Method.paypalDirect.rawValue
+        }) ?? self.transaction?.paymentMethods.first
+    }
+
+    private func selectDefaultPaymentMethod() {
+        if let appcPaymentMethod = self.transaction?.paymentMethods.first(where: { $0.name == Method.appc.rawValue && !$0.disabled }) {
+            self.lastPaymentMethod = appcPaymentMethod
+            self.paymentMethodSelected = appcPaymentMethod
+        } else if let fallback = findFallbackPaymentMethod() {
+            self.paymentMethodSelected = fallback
+            self.showOtherPaymentMethods = true
         }
     }
     

--- a/Sources/AppCoinsSDK/UI/Purchase/ViewModels/TransactionViewModel.swift
+++ b/Sources/AppCoinsSDK/UI/Purchase/ViewModels/TransactionViewModel.swift
@@ -192,105 +192,6 @@ internal class TransactionViewModel : ObservableObject {
         }
     }
     
-//    private func showPaymentMethodsOnBuild(balance: Balance) {
-//        // Other Payment Methods filtering
-//        if balance.appcoinsBalance < self.transaction?.appcAmount ?? 0 {
-//            if let index = self.transaction?.paymentMethods.firstIndex(where: { $0.name == Method.appc.rawValue }) {
-//                if var appcPM = self.transaction?.paymentMethods.remove(at: index) {
-//                    appcPM.disabled = true
-//                    self.transaction?.paymentMethods.append(appcPM)
-//                }
-//            }
-//        }
-//        
-//        // Quick view of last payment method used
-//        let lastPaymentMethod = self.transactionUseCases.getLastPaymentMethod()
-//        if let lastPaymentMethod = lastPaymentMethod {
-//            switch lastPaymentMethod {
-//            case Method.appc:
-//                if let appcPM = self.transaction?.paymentMethods.first(where: { $0.name == Method.appc.rawValue && $0.disabled == false }) {
-//                    self.lastPaymentMethod = appcPM
-//                    self.paymentMethodSelected = appcPM
-//                } else {
-//                    if let paypal = self.transaction?.paymentMethods.first(where: { $0.name == Method.paypalAdyen.rawValue || $0.name == Method.paypalDirect.rawValue }) {
-//                        self.paymentMethodSelected = paypal
-//                    } else if let selected = self.transaction?.paymentMethods.first {
-//                        self.paymentMethodSelected = selected
-//                    }
-//                    self.showOtherPaymentMethods = true
-//                }
-//            case Method.paypalAdyen:
-//                if let paypalPM = self.transaction?.paymentMethods.first(where: { $0.name == Method.paypalAdyen.rawValue }) {
-//                    self.lastPaymentMethod = paypalPM
-//                    self.paymentMethodSelected = paypalPM
-//                } else {
-//                    if let paypal = self.transaction?.paymentMethods.first(where: { $0.name == Method.paypalAdyen.rawValue || $0.name == Method.paypalDirect.rawValue }) {
-//                        self.paymentMethodSelected = paypal
-//                    } else if let selected = self.transaction?.paymentMethods.first {
-//                        self.paymentMethodSelected = selected
-//                    }
-//                    self.showOtherPaymentMethods = true
-//                }
-//            case Method.paypalDirect:
-//                if let paypalPM = self.transaction?.paymentMethods.first(where: { $0.name == Method.paypalDirect.rawValue }) {
-//                    if self.transactionUseCases.hasBillingAgreement() { self.paypalLogOut = true }
-//                    self.lastPaymentMethod = paypalPM
-//                    self.paymentMethodSelected = paypalPM
-//                } else {
-//                    if let paypal = self.transaction?.paymentMethods.first(where: { $0.name == Method.paypalAdyen.rawValue || $0.name == Method.paypalDirect.rawValue }) {
-//                        self.paymentMethodSelected = paypal
-//                    } else if let selected = self.transaction?.paymentMethods.first {
-//                        self.paymentMethodSelected = selected
-//                    }
-//                    self.showOtherPaymentMethods = true
-//                }
-//            case Method.creditCard:
-//                if let ccPM = self.transaction?.paymentMethods.first(where: { $0.name == Method.creditCard.rawValue }) {
-//                    self.lastPaymentMethod = ccPM
-//                    self.paymentMethodSelected = ccPM
-//                } else {
-//                    if let paypal = self.transaction?.paymentMethods.first(where: { $0.name == Method.paypalAdyen.rawValue || $0.name == Method.paypalDirect.rawValue }) {
-//                        self.paymentMethodSelected = paypal
-//                    } else if let selected = self.transaction?.paymentMethods.first {
-//                        self.paymentMethodSelected = selected
-//                    }
-//                    self.showOtherPaymentMethods = true
-//                }
-//            case Method.sandbox:
-//                if let sandboxPM = self.transaction?.paymentMethods.first(where: { $0.name == Method.sandbox.rawValue }) {
-//                    self.lastPaymentMethod = sandboxPM
-//                    self.paymentMethodSelected = sandboxPM
-//                } else {
-//                    if let paypal = self.transaction?.paymentMethods.first(where: { $0.name == Method.paypalAdyen.rawValue || $0.name == Method.paypalDirect.rawValue }) {
-//                        self.paymentMethodSelected = paypal
-//                    } else if let selected = self.transaction?.paymentMethods.first {
-//                        self.paymentMethodSelected = selected
-//                    }
-//                    self.showOtherPaymentMethods = true
-//                }
-//            default:
-//                if let paypal = self.transaction?.paymentMethods.first(where: { $0.name == Method.paypalAdyen.rawValue || $0.name == Method.paypalDirect.rawValue }) {
-//                    self.paymentMethodSelected = paypal
-//                } else if let selected = self.transaction?.paymentMethods.first {
-//                    self.paymentMethodSelected = selected
-//                }
-//                self.showOtherPaymentMethods = true
-//            }
-//        } else {
-//            if let appcPM = self.transaction?.paymentMethods.first(where: { $0.name == Method.appc.rawValue && $0.disabled == false }) {
-//                self.lastPaymentMethod = appcPM
-//                self.paymentMethodSelected = appcPM
-//            } else {
-//                if let paypal = self.transaction?.paymentMethods.first(where: { $0.name == Method.paypalAdyen.rawValue || $0.name == Method.paypalDirect.rawValue }) {
-//                    self.paymentMethodSelected = paypal
-//                } else if let selected = self.transaction?.paymentMethods.first {
-//                    self.paymentMethodSelected = selected
-//                }
-//                self.showOtherPaymentMethods = true
-//            }
-//        }
-//    }
-    
     private func showPaymentMethodsOnBuild(balance: Balance) {
         // Filter out the AppCoins payment method if balance is insufficient
         disableAppCoinsIfNeeded(balance: balance)
@@ -301,52 +202,52 @@ internal class TransactionViewModel : ObservableObject {
         } else {
             selectDefaultPaymentMethod()
         }
-    }
-
-    private func disableAppCoinsIfNeeded(balance: Balance) {
-        if balance.appcoinsBalance < self.transaction?.appcAmount ?? 0,
-           let index = self.transaction?.paymentMethods.firstIndex(where: { $0.name == Method.appc.rawValue }) {
-            if var appcPaymentMethod = self.transaction?.paymentMethods[index] {
-                appcPaymentMethod.disable()
-                self.transaction?.paymentMethods[index] = appcPaymentMethod
+        
+        func disableAppCoinsIfNeeded(balance: Balance) {
+            if balance.appcoinsBalance < self.transaction?.appcAmount ?? 0,
+               let index = self.transaction?.paymentMethods.firstIndex(where: { $0.name == Method.appc.rawValue }) {
+                if var appcPaymentMethod = self.transaction?.paymentMethods[index] {
+                    appcPaymentMethod.disable()
+                    self.transaction?.paymentMethods[index] = appcPaymentMethod
+                }
             }
         }
-    }
-
-    private func showQuickPaymentMethod(_ lastPaymentMethod: Method) {
-        if let selectedMethod = self.transaction?.paymentMethods.first(where: { $0.name == lastPaymentMethod.rawValue && !$0.disabled }) {
-            self.lastPaymentMethod = selectedMethod
-            self.paymentMethodSelected = selectedMethod
-        } else {
-            handleFallbackPaymentMethod(for: lastPaymentMethod)
+        
+        func selectDefaultPaymentMethod() {
+            if let appcPaymentMethod = self.transaction?.paymentMethods.first(where: { $0.name == Method.appc.rawValue && !$0.disabled }) {
+                self.lastPaymentMethod = appcPaymentMethod
+                self.paymentMethodSelected = appcPaymentMethod
+            } else if let fallback = findFallbackPaymentMethod() {
+                self.paymentMethodSelected = fallback
+                self.showOtherPaymentMethods = true
+            }
         }
-    }
 
-    private func handleFallbackPaymentMethod(for method: Method) {
-        if let fallback = findFallbackPaymentMethod() {
-            self.paymentMethodSelected = fallback
+        func showQuickPaymentMethod(_ lastPaymentMethod: Method) {
+            if let selectedMethod = self.transaction?.paymentMethods.first(where: { $0.name == lastPaymentMethod.rawValue && !$0.disabled }) {
+                self.lastPaymentMethod = selectedMethod
+                self.paymentMethodSelected = selectedMethod
+            } else {
+                handleFallbackPaymentMethod(for: lastPaymentMethod)
+            }
+            
+            func handleFallbackPaymentMethod(for method: Method) {
+                if let fallback = findFallbackPaymentMethod() {
+                    self.paymentMethodSelected = fallback
+                }
+                
+                if method == .paypalDirect, self.transactionUseCases.hasBillingAgreement() {
+                    self.paypalLogOut = true
+                }
+                
+                self.showOtherPaymentMethods = true
+            }
         }
         
-        if method == .paypalDirect, self.transactionUseCases.hasBillingAgreement() {
-            self.paypalLogOut = true
-        }
-        
-        self.showOtherPaymentMethods = true
-    }
-
-    private func findFallbackPaymentMethod() -> PaymentMethod? {
-        return self.transaction?.paymentMethods.first(where: {
-            $0.name == Method.paypalAdyen.rawValue || $0.name == Method.paypalDirect.rawValue
-        }) ?? self.transaction?.paymentMethods.first
-    }
-
-    private func selectDefaultPaymentMethod() {
-        if let appcPaymentMethod = self.transaction?.paymentMethods.first(where: { $0.name == Method.appc.rawValue && !$0.disabled }) {
-            self.lastPaymentMethod = appcPaymentMethod
-            self.paymentMethodSelected = appcPaymentMethod
-        } else if let fallback = findFallbackPaymentMethod() {
-            self.paymentMethodSelected = fallback
-            self.showOtherPaymentMethods = true
+        func findFallbackPaymentMethod() -> PaymentMethod? {
+            return self.transaction?.paymentMethods.first(where: {
+                $0.name == Method.paypalAdyen.rawValue || $0.name == Method.paypalDirect.rawValue
+            }) ?? self.transaction?.paymentMethods.first
         }
     }
     


### PR DESCRIPTION
**What does this PR do?**

This PR introduces sandboxed payments, enabling developers to test their integrations with the AppCoins SDK. Additionally, it refactors the `showPaymentMethodsOnBuild()` method, which had become too extensive. The PR also removes the origin parameter from the broker's create transaction methods.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] Sources/AppCoinsSDK/UI/Purchase/ViewModels/BottomSheetViewModel.swift
- [ ] Sources/AppCoinsSDK/UI/Purchase/ViewModels/TransactionViewModel.swift
- [ ] Sources/AppCoinsSDK/Models/Services/Billing/AppCoinBillingClient.swift

**How should this be manually tested?**

Try the Sandbox payment in dev by adding a wallet on catappult console.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2794](https://aptoide.atlassian.net/browse/APP-2794)

**Questions:**



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass
