### PR TITLE
Light mode forced

### DIFF
--- a/Sources/AppCoinsSDK/Localization/Localizable.xcstrings
+++ b/Sources/AppCoinsSDK/Localization/Localizable.xcstrings
@@ -1,6 +1,9 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "" : {
+
+    },
     "add_card_button" : {
       "comment" : "Add new card",
       "extractionState" : "manual",

--- a/Sources/AppCoinsSDK/UI/Purchase/Controllers/PurchaseViewController.swift
+++ b/Sources/AppCoinsSDK/UI/Purchase/Controllers/PurchaseViewController.swift
@@ -15,7 +15,10 @@ internal class PurchaseViewController: UIViewController {
     
     override internal func viewDidLoad() {
         super.viewDidLoad()
+        
         updateOrientation()
+        
+        overrideUserInterfaceStyle = .light
         
         // Add the bottom sheet view
         let bottomSheetView = BottomSheetView()


### PR DESCRIPTION
**What does this PR do?**

   This PR forces light mode on the AppCoins SDK

**Database changed?**

No

**Where should the reviewer start?**

- [ ] PurchaseViewController.swift

**How should this be manually tested?**

  Run Trivial Drive and test the SDK while the device’s dark mode is enabled

**What are the relevant tickets?**

  Tickets related to this pull-request: APP-3115

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass
