### PR TITLE
Bugfix/APP-3202 Payment Method Icons Disappear Randomly

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,6 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/web3swift-team/web3swift.git", .upToNextMinor(from: "3.2.0")),
         .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .upToNextMinor(from: "1.5.1")),
-        .package(url: "https://github.com/dmytro-anokhin/url-image.git", .upToNextMinor(from: "3.0.0")),
         .package(url: "https://github.com/CSolanaM/SkeletonUI.git", .upToNextMinor(from: "2.0.1")),
         .package(url: "https://github.com/TakeScoop/SwiftyRSA.git", .upToNextMinor(from: "1.8.0")),
         .package(url: "https://github.com/Adyen/adyen-ios.git", exact: "5.12.0"),
@@ -32,7 +31,6 @@ let package = Package(
         .target(
             name: "AppCoinsSDK",
             dependencies: [
-                .product(name: "URLImage", package: "url-image"),
                 .product(name: "CryptoSwift", package: "CryptoSwift"),
                 .product(name: "web3swift", package: "web3swift"),
                 .product(name: "SkeletonUI", package: "SkeletonUI"),

--- a/Sources/AppCoinsSDK/UI/Purchase/Cells/CreditCardAdyenIcon.swift
+++ b/Sources/AppCoinsSDK/UI/Purchase/Cells/CreditCardAdyenIcon.swift
@@ -6,39 +6,47 @@
 //
 
 import SwiftUI
-@_implementationOnly import URLImage
 
 internal struct CreditCardAdyenIcon: View {
     
     internal var image: URL
     
     internal var body: some View {
- 
-        URLImage(image,
-                 inProgress: { progress in
+        
+        if #available(iOS 15.0, *) {
+            AsyncImage(url: image) { phase in
+                switch phase {
+                case .empty:
                     Image("card-placeholder", bundle: Bundle.APPCModule)
                         .resizable()
                         .scaledToFit()
                         .edgesIgnoringSafeArea(.all)
                         .frame(width: 25)
                         .padding(.horizontal, 5)
-                 },
-                 failure: { error, retry in
-                    Image("card-placeholder", bundle: Bundle.APPCModule)
-                        .resizable()
-                        .scaledToFit()
-                        .edgesIgnoringSafeArea(.all)
-                        .frame(width: 25)
-                        .padding(.horizontal, 5)
-                },
-                 content: {
-                    image in
+                    
+                case .success(let image):
                     image
                         .resizable()
                         .scaledToFit()
                         .edgesIgnoringSafeArea(.all)
                         .frame(width: 35)
-                    }
-            )
+                    
+                case .failure:
+                    Image("card-placeholder", bundle: Bundle.APPCModule)
+                        .resizable()
+                        .scaledToFit()
+                        .edgesIgnoringSafeArea(.all)
+                        .frame(width: 25)
+                        .padding(.horizontal, 5)
+                }
+            }
+        } else {
+            Image("card-placeholder", bundle: Bundle.APPCModule)
+                .resizable()
+                .scaledToFit()
+                .edgesIgnoringSafeArea(.all)
+                .frame(width: 25)
+                .padding(.horizontal, 5)
+        }
     }
 }

--- a/Sources/AppCoinsSDK/UI/Purchase/Cells/PaymentMethodIcon.swift
+++ b/Sources/AppCoinsSDK/UI/Purchase/Cells/PaymentMethodIcon.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-@_implementationOnly import URLImage
 
 internal struct PaymentMethodIcon: View {
     
@@ -14,30 +13,36 @@ internal struct PaymentMethodIcon: View {
     internal var disabled: Bool
     
     internal var body: some View {
-        if let icon = URL(string: icon) {
-            URLImage(icon,
-                     inProgress: {
-                progress in
-                   RoundedRectangle(cornerRadius: 0)
-                       .foregroundColor(ColorsUi.APC_White)
-                       .frame(width: 24, height: 24)
-                       .clipShape(Circle())
-            }, failure: {
-                error,retry in
-                   RoundedRectangle(cornerRadius: 0)
-                       .foregroundColor(ColorsUi.APC_White)
-                       .frame(width: 24, height: 24)
-                       .clipShape(Circle())
-                        .onAppear{ retry() }
-            }, content: {
-                image in
+        if let icon = URL(string: icon), #available(iOS 15.0, *) {
+            AsyncImage(url: icon) { phase in
+                switch phase {
+                case .empty:
+                    RoundedRectangle(cornerRadius: 0)
+                        .foregroundColor(ColorsUi.APC_White)
+                        .frame(width: 24, height: 24)
+                        .clipShape(Circle())
+                    
+                case .success(let image):
                     image
                         .resizable()
                         .edgesIgnoringSafeArea(.all)
                         .frame(width: 24, height: 24)
                         .opacity(disabled ? 0.2 : 1)
-            }).padding(.trailing, 16)
-                .padding(.leading, 16)
+                    
+                case .failure:
+                    RoundedRectangle(cornerRadius: 0)
+                        .foregroundColor(ColorsUi.APC_White)
+                        .frame(width: 24, height: 24)
+                        .clipShape(Circle())
+                }
+            }
+            .padding(.trailing, 16)
+            .padding(.leading, 16)
+        } else {
+            RoundedRectangle(cornerRadius: 0)
+                .foregroundColor(ColorsUi.APC_White)
+                .frame(width: 24, height: 24)
+                .clipShape(Circle())
         }
     }
 }

--- a/Sources/AppCoinsSDK/UI/Purchase/Cells/PaymentMethodQuickIcon.swift
+++ b/Sources/AppCoinsSDK/UI/Purchase/Cells/PaymentMethodQuickIcon.swift
@@ -6,33 +6,39 @@
 //
 
 import SwiftUI
-@_implementationOnly import URLImage
 
 internal struct PaymentMethodQuickIcon: View {
     
     internal var icon: URL
     
     internal var body: some View {
-        URLImage(icon,
-                 inProgress: { progress in
+        if #available(iOS 15.0, *) {
+            AsyncImage(url: icon) { phase in
+                switch phase {
+                case .empty:
                     RoundedRectangle(cornerRadius: 0)
                         .foregroundColor(ColorsUi.APC_LightGray)
                         .frame(width: 48, height: 48)
                         .clipShape(Circle())
-                    },
-                 failure: {error,retry in
-                    RoundedRectangle(cornerRadius: 0)
-                        .foregroundColor(ColorsUi.APC_LightGray)
-                        .frame(width: 48, height: 48)
-                        .clipShape(Circle())
-                        .onAppear{ retry() }},
-                 content: {
-                    image in
+                    
+                case .success(let image):
                     image
                         .resizable()
                         .edgesIgnoringSafeArea(.all)
                         .frame(width: 48, height: 48)
+                    
+                case .failure:
+                    RoundedRectangle(cornerRadius: 0)
+                        .foregroundColor(ColorsUi.APC_LightGray)
+                        .frame(width: 48, height: 48)
+                        .clipShape(Circle())
                 }
-        )
+            }
+        } else {
+            RoundedRectangle(cornerRadius: 0)
+                .foregroundColor(ColorsUi.APC_LightGray)
+                .frame(width: 48, height: 48)
+                .clipShape(Circle())
+        }
     }
 }

--- a/Sources/AppCoinsSDK/UI/Purchase/Cells/PaymentMethodView.swift
+++ b/Sources/AppCoinsSDK/UI/Purchase/Cells/PaymentMethodView.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import SwiftUI
-@_implementationOnly import URLImage
 
 internal struct PaymentMethodView: View, Identifiable, Equatable {
     
@@ -18,32 +17,37 @@ internal struct PaymentMethodView: View, Identifiable, Equatable {
     
     internal var body: some View {
         HStack(spacing: 0) {
-            if let icon = URL(string: icon) {
-                URLImage(icon,
-                         inProgress: {
-                    progress in
-                       RoundedRectangle(cornerRadius: 0)
-                           .foregroundColor(ColorsUi.APC_White)
-                           .frame(width: 24, height: 24)
-                           .clipShape(Circle())
-                }, failure: {
-                    error,retry in
-                       RoundedRectangle(cornerRadius: 0)
-                           .foregroundColor(ColorsUi.APC_White)
-                           .frame(width: 24, height: 24)
-                           .clipShape(Circle())
-                            .onAppear{ retry() }
-                },
-                         content: {
-                    image in
+            if let icon = URL(string: icon), #available(iOS 15.0, *) {
+                AsyncImage(url: icon) { phase in
+                    switch phase {
+                    case .empty:
+                        RoundedRectangle(cornerRadius: 0)
+                            .foregroundColor(ColorsUi.APC_White)
+                            .frame(width: 24, height: 24)
+                            .clipShape(Circle())
+                        
+                    case .success(let image):
                         image
                             .resizable()
                             .edgesIgnoringSafeArea(.all)
                             .frame(width: 24, height: 24)
                             .opacity(disabled ? 0.2 : 1)
-                }).padding(.trailing, 16)
-                    .padding(.leading, 8)
-                    .animation(.easeIn(duration: 0.3))
+                        
+                    case .failure:
+                        RoundedRectangle(cornerRadius: 0)
+                            .foregroundColor(ColorsUi.APC_White)
+                            .frame(width: 24, height: 24)
+                            .clipShape(Circle())
+                    }
+                }
+                .padding(.trailing, 16)
+                .padding(.leading, 8)
+                .animation(.easeIn(duration: 0.3))
+            } else {
+                RoundedRectangle(cornerRadius: 0)
+                    .foregroundColor(ColorsUi.APC_White)
+                    .frame(width: 24, height: 24)
+                    .clipShape(Circle())
             }
             
             Text(name)

--- a/Sources/AppCoinsSDK/UI/Purchase/PurchaseStateViews/PurchaseBottomSheet.swift
+++ b/Sources/AppCoinsSDK/UI/Purchase/PurchaseStateViews/PurchaseBottomSheet.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import SwiftUI
-@_implementationOnly import URLImage
 @_implementationOnly import SkeletonUI
 @_implementationOnly import ActivityIndicatorView
 


### PR DESCRIPTION
**What does this PR do?**

Fixes a bug where payment method icons randomly disappeared by replacing URLImage (the library we used to display images from URLs) by AsyncImage (Apple’s official support library introduced with iOS 15).

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] Sources/AppCoinsSDK/UI/Purchase/Cells/CreditCardAdyenIcon.swift
- [ ] Sources/AppCoinsSDK/UI/Purchase/Cells/PaymentMethodIcon.swift
- [ ] Sources/AppCoinsSDK/UI/Purchase/Cells/PaymentMethodQuickIcon.swift

**How should this be manually tested?**

Already available for testing on TestFlight, simply check if payment method icons are no longer disappearing.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-3202](https://aptoide.atlassian.net/browse/APP-3202)

**Questions:**



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass
