### PR TITLE
feature/APP-3539 Generalize Handling Of Web Checkout Redirect

### DIFF
--- a/Sources/AppCoinsSDK/UI/Controllers/WebPaymentInterface/Methods/HandleIOSRedirect/HandleIOSRedirect.swift
+++ b/Sources/AppCoinsSDK/UI/Controllers/WebPaymentInterface/Methods/HandleIOSRedirect/HandleIOSRedirect.swift
@@ -1,5 +1,5 @@
 //
-//  HandleAuthenticationRedirect.swift
+//  HandleIOSRedirect.swift
 //
 //
 //  Created by aptoide on 07/04/2025.
@@ -8,15 +8,15 @@
 import SwiftUI
 @_implementationOnly import AuthenticationServices
 
-internal class HandleAuthenticationRedirect: NSObject {
+internal class HandleIOSRedirect: NSObject {
     
-    internal static let shared = HandleAuthenticationRedirect()
+    internal static let shared = HandleIOSRedirect()
     
     private override init() {}
     
-    internal func handle(body: HandleAuthenticationRedirectBody) {
+    internal func handle(body: HandleIOSRedirectBody) {
         guard let authenticationURL = URL(string: body.URL) else {
-            Utils.log("Invalid URL on handleAuthenticationRedirect")
+            Utils.log("Invalid URL on handleIOSRedirect")
             return
         }
       
@@ -24,11 +24,11 @@ internal class HandleAuthenticationRedirect: NSObject {
         var authSession = ASWebAuthenticationSession(url: authenticationURL, callbackURLScheme: "\(Bundle.main.bundleIdentifier).iap") { callbackURL, error in
             
             if let error = error { 
-                Utils.log("Error on handleAuthenticationRedirect: \(error.localizedDescription)")
+                Utils.log("Error on handleIOSRedirect: \(error.localizedDescription)")
                 return
             }
             guard let callbackURL = callbackURL else { 
-                Utils.log("Invalid callback URL on handleAuthenticationRedirect")
+                Utils.log("Invalid callback URL on handleIOSRedirect")
                 return
             }
             
@@ -43,7 +43,7 @@ internal class HandleAuthenticationRedirect: NSObject {
 }
 
 // Conform to ASWebAuthenticationPresentationContextProviding
-extension HandleAuthenticationRedirect: ASWebAuthenticationPresentationContextProviding {
+extension HandleIOSRedirect: ASWebAuthenticationPresentationContextProviding {
     internal func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
         return UIApplication.shared.windows.first(where: { $0.isKeyWindow }) ?? ASPresentationAnchor()
     }

--- a/Sources/AppCoinsSDK/UI/Controllers/WebPaymentInterface/Methods/HandleIOSRedirect/HandleIOSRedirectBody.swift
+++ b/Sources/AppCoinsSDK/UI/Controllers/WebPaymentInterface/Methods/HandleIOSRedirect/HandleIOSRedirectBody.swift
@@ -1,5 +1,5 @@
 //
-//  HandleAuthenticationRedirectBody.swift
+//  HandleIOSRedirectBody.swift
 //
 //
 //  Created by aptoide on 07/04/2025.
@@ -7,7 +7,7 @@
 
 import Foundation
 
-internal struct HandleAuthenticationRedirectBody: Codable {
+internal struct HandleIOSRedirectBody: Codable {
     
     internal let URL: String
     

--- a/Sources/AppCoinsSDK/UI/Controllers/WebPaymentInterface/Methods/WebPaymentInterfaceMethod.swift
+++ b/Sources/AppCoinsSDK/UI/Controllers/WebPaymentInterface/Methods/WebPaymentInterfaceMethod.swift
@@ -10,7 +10,7 @@ import Foundation
 internal enum WebPaymentInterfaceMethod: String {
     case onPurchaseResult = "onPurchaseResult"
     case onError = "onError"
-    case handleAuthenticationRedirect = "handleAuthenticationRedirect"
+    case handleIOSRedirect = "handleIOSRedirect"
     case handleExternalRedirect = "handleExternalRedirect"
     case setActiveWallet = "setActiveWallet"
 }

--- a/Sources/AppCoinsSDK/UI/Controllers/WebPaymentInterface/WebPaymentInterface.swift
+++ b/Sources/AppCoinsSDK/UI/Controllers/WebPaymentInterface/WebPaymentInterface.swift
@@ -49,12 +49,12 @@ internal class WebPaymentInterface: NSObject, WKScriptMessageHandler {
                 Utils.log("Failed to parse onError body with error: \(error)")
                 return
             }
-        case .handleAuthenticationRedirect:
+        case .handleIOSRedirect:
             do {
-                let handleAuthenticationRedirectBody = try JSONDecoder().decode(HandleAuthenticationRedirectBody.self, from: params)
-                HandleAuthenticationRedirect.shared.handle(body: handleAuthenticationRedirectBody)
+                let handleIOSRedirectBody = try JSONDecoder().decode(HandleIOSRedirectBody.self, from: params)
+                HandleIOSRedirect.shared.handle(body: handleIOSRedirectBody)
             } catch {
-                Utils.log("Failed to parse handleAuthenticationRedirect body with error: \(error)")
+                Utils.log("Failed to parse handleIOSRedirect body with error: \(error)")
                 return
             }
         case .handleExternalRedirect:

--- a/Sources/AppCoinsSDK/UI/ViewModels/TransactionViewModel.swift
+++ b/Sources/AppCoinsSDK/UI/ViewModels/TransactionViewModel.swift
@@ -125,11 +125,11 @@ internal class TransactionViewModel: ObservableObject {
         let trimmedPrefixURL = trimmedURL.hasPrefix("//") ? String(trimmedURL.dropFirst(2)) : trimmedURL
         let finalURL = trimmedPrefixURL.hasSuffix("#") ? String(trimmedPrefixURL.dropLast(1)) : trimmedPrefixURL
         
-        webView.evaluateJavaScript("window.handleAuthenticationRedirect('\(finalURL)')") { result, error in
+        webView.evaluateJavaScript("window.handleIOSRedirect('\(finalURL)')") { result, error in
             if let error = error {
                 Utils.log("Error sending message to WebView: \(error.localizedDescription)")
             } else {
-                Utils.log("Called window.handleAuthenticationRedirect('\(finalURL)') successfully")
+                Utils.log("Called window.handleIOSRedirect('\(finalURL)') successfully")
             }
         }
     }


### PR DESCRIPTION
**What does this PR do?**
   
This pull request renames handleAuthenticationRedirect to handleIOSRedirect across the codebase
   
**Database changed?**

   No

**Where should the reviewer start?**

- [ ] HandleAuthenticationRedirect.swift
- [ ] HandleAuthenticationRedirectBody.swift
- [ ] WebPaymentInterfaceMethod.swift
- [ ] WebPaymentInterface.swift
- [ ] TransactionViewModel.swift

**How should this be manually tested?**

**What are the relevant tickets?**

  Tickets related to this pull-request: APP-3539

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass
