### PR TITLE
Feature/APP-3540 Use SFSafariViewController For Browser Dependent Payment Methods

### DIFF
--- a/Sources/AppCoinsSDK/UI/Controllers/SDKViewController.swift
+++ b/Sources/AppCoinsSDK/UI/Controllers/SDKViewController.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SwiftUI
+@_implementationOnly import SafariServices
 
 internal struct SDKViewController {
     
@@ -17,5 +18,14 @@ internal struct SDKViewController {
         let purchaseViewController = PurchaseViewController()
         purchaseViewController.modalPresentationStyle = .overFullScreen
         rootViewController.present(purchaseViewController, animated: false, completion: nil)
+    }
+    
+    internal static func presentSafariSheet(url: URL) {
+        guard let topViewController = UIApplication.shared.topMostViewController() else {
+            return
+        }
+        let safariVC = SFSafariViewController(url: url)
+        safariVC.modalPresentationStyle = .pageSheet
+        topViewController.present(safariVC, animated: true)
     }
 }

--- a/Sources/AppCoinsSDK/UI/Controllers/WebPaymentInterface/Methods/HandleInternalRedirect/HandleInternalRedirect.swift
+++ b/Sources/AppCoinsSDK/UI/Controllers/WebPaymentInterface/Methods/HandleInternalRedirect/HandleInternalRedirect.swift
@@ -18,12 +18,8 @@ internal class HandleInternalRedirect {
             Utils.log("Invalid URL on handleInternalRedirect")
             return
         }
-
-        if UIApplication.shared.canOpenURL(URL) {
-            SDKViewController.presentSafariSheet(url: URL)
-        } else {
-            Utils.log("Cannot open URL on handleExternalRedirect")
-        }
+        
+        SDKViewController.presentSafariSheet(url: URL)
     }
     
 }

--- a/Sources/AppCoinsSDK/UI/Controllers/WebPaymentInterface/Methods/HandleInternalRedirect/HandleInternalRedirect.swift
+++ b/Sources/AppCoinsSDK/UI/Controllers/WebPaymentInterface/Methods/HandleInternalRedirect/HandleInternalRedirect.swift
@@ -1,0 +1,29 @@
+//
+//  HandleInternalRedirect.swift
+//  AppCoinsSDK
+//
+//  Created by Graciano Caldeira on 06/05/2025.
+//
+
+import SwiftUI
+
+internal class HandleInternalRedirect {
+    
+    internal static let shared = HandleInternalRedirect()
+    
+    private init() {}
+    
+    internal func handle(body: HandleInternalRedirectBody) {
+        guard let URL = URL(string: body.URL) else {
+            Utils.log("Invalid URL on handleInternalRedirect")
+            return
+        }
+
+        if UIApplication.shared.canOpenURL(URL) {
+            SDKViewController.presentSafariSheet(url: URL)
+        } else {
+            Utils.log("Cannot open URL on handleExternalRedirect")
+        }
+    }
+    
+}

--- a/Sources/AppCoinsSDK/UI/Controllers/WebPaymentInterface/Methods/HandleInternalRedirect/HandleInternalRedirectBody.swift
+++ b/Sources/AppCoinsSDK/UI/Controllers/WebPaymentInterface/Methods/HandleInternalRedirect/HandleInternalRedirectBody.swift
@@ -1,0 +1,17 @@
+//
+//  HandleInternalRedirectBody.swift
+//  AppCoinsSDK
+//
+//  Created by Graciano Caldeira on 06/05/2025.
+//
+
+import Foundation
+
+internal struct HandleInternalRedirectBody: Codable {
+    
+    internal let URL: String
+    
+    internal enum CodingKeys: String, CodingKey {
+        case URL = "URL"
+    }
+}

--- a/Sources/AppCoinsSDK/UI/Controllers/WebPaymentInterface/Methods/WebPaymentInterfaceMethod.swift
+++ b/Sources/AppCoinsSDK/UI/Controllers/WebPaymentInterface/Methods/WebPaymentInterfaceMethod.swift
@@ -12,5 +12,6 @@ internal enum WebPaymentInterfaceMethod: String {
     case onError = "onError"
     case handleAuthenticationRedirect = "handleAuthenticationRedirect"
     case handleExternalRedirect = "handleExternalRedirect"
+    case handleInternalRedirect = "handleInternalRedirect"
     case setActiveWallet = "setActiveWallet"
 }

--- a/Sources/AppCoinsSDK/UI/Controllers/WebPaymentInterface/WebPaymentInterface.swift
+++ b/Sources/AppCoinsSDK/UI/Controllers/WebPaymentInterface/WebPaymentInterface.swift
@@ -73,6 +73,14 @@ internal class WebPaymentInterface: NSObject, WKScriptMessageHandler {
                 Utils.log("Failed to parse setActiveWallet body body with error: \(error)")
                 return
             }
+        case .handleInternalRedirect:
+            do {
+                let handleInternalRedirectBody = try JSONDecoder().decode(HandleInternalRedirectBody.self, from: params)
+                HandleInternalRedirect.shared.handle(body: handleInternalRedirectBody)
+            } catch {
+                Utils.log("Failed to parse handleInternalRedirect body with error: \(error)")
+                return
+            }
         }
     }
 }

--- a/Sources/AppCoinsSDK/Utils/TopMostViewController.swift
+++ b/Sources/AppCoinsSDK/Utils/TopMostViewController.swift
@@ -1,0 +1,33 @@
+//
+//  File.swift
+//  AppCoinsSDK
+//
+//  Created by Graciano Caldeira on 06/05/2025.
+//
+
+import UIKit
+
+internal extension UIApplication {
+    
+    func topMostViewController(base: UIViewController? = { return UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first(where: { $0.isKeyWindow })?
+            .rootViewController
+    }()) -> UIViewController? {
+        
+        if let nav = base as? UINavigationController {
+            return topMostViewController(base: nav.visibleViewController)
+        }
+        
+        if let tab = base as? UITabBarController {
+            return topMostViewController(base: tab.selectedViewController)
+        }
+        
+        if let presented = base?.presentedViewController {
+            return topMostViewController(base: presented)
+        }
+        
+        return base
+    }
+}


### PR DESCRIPTION
**What does this PR do?**

   This PR introduces the use of SFSafariViewController in the WebCheckout flow as an alternative to WKWebView for payment methods that are browser-dependent. It also adds the logic needed to handle internal redirect deep links.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] HandleInternalRedirect.swift
- [ ] HandleInternalRedirectBody.swift
- [ ] TopMostViewController.swift
- [ ] WebPaymentInterfaceMethod.swift
- [ ] WebPaymentInterface.swift

**How should this be manually tested?**

  In the BottomSheetView it is possible to add a button on top of the WebCheckoutView and call SDKViewController.presentSafariSheet with a valid URL.

**What are the relevant tickets?**

  Tickets related to this pull-request: APP-3540

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass
