### PR TITLE
Feature/APP-3204 Allow Distribution for Alternative App Stores

### DIFF
--- a/Sources/AppCoinsSDK/Domain/Entities/AppcSDK.swift
+++ b/Sources/AppCoinsSDK/Domain/Entities/AppcSDK.swift
@@ -170,15 +170,18 @@ public struct AppcSDK {
                 return false
             }
             
-            let storefront = try await AppDistributor.current
-            switch storefront {
-            case .appStore:
-                return false
-            case .marketplace(let marketplace):
-                return marketplace == "com.aptoide.ios.store"
-            default:
+            #if targetEnvironment(simulator)
+                Utils.log("Can't validate App Distributor on Simulator. To test different billings (Apple vs. Aptoide) use an actual device or enable AppCoinsDevTools.")
                 return true
-            }
+            #else
+                let storefront = try await AppDistributor.current
+                switch storefront {
+                case .appStore:
+                    return false
+                default:
+                    return true
+                }
+            #endif
         } catch {
             return false
         }


### PR DESCRIPTION
**What does this PR do?**

   Allows distribution for simulator and alternative App Stores that are not Aptoide.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] Sources/AppCoinsSDK/Domain/Entities/AppcSDK.swift

**How should this be manually tested?**

   Verify if, with a European Union StoreKit configuration, you can launch a checkout webview from a simulator.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-3204](https://aptoide.atlassian.net/browse/APP-3204)

**Questions:**



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass
